### PR TITLE
KammusuIndexの定義を変更

### DIFF
--- a/KCS_CUI/source/fleet.cpp
+++ b/KCS_CUI/source/fleet.cpp
@@ -109,7 +109,7 @@ void Fleet::LoadJson(std::istream & file, const WeaponDB & weapon_db, const Kamm
 				if (wi >= temp_k.GetSlots()) break;
 			}
 			// リストに加える
-			unit_[fi].push_back(temp_k);
+			unit_[fi].push_back(move(temp_k));
 		}
 		++fi;
 	}
@@ -326,9 +326,9 @@ int Fleet::RandomKammusu() {
 
 // 生存する水上艦から艦娘をランダムに指定する
 // ただしhas_bombがtrueの際は陸上型棲姫を避けるようになる
-int Fleet::RandomKammusuNonSS(const bool &has_bomb) {
+std::pair<std::size_t, std::size_t> Fleet::RandomKammusuNonSS(const bool &has_bomb) {
 	//生存する水上艦をリストアップ
-	vector<int> alived_list;
+	KammusuIndex alived_list;
 	for (auto ui = 0u; ui < FirstUnit().size(); ++ui) {
 		auto &it_k = FirstUnit()[ui];
 		if (it_k.Status() == kStatusLost) continue;
@@ -336,8 +336,8 @@ int Fleet::RandomKammusuNonSS(const bool &has_bomb) {
 		if (has_bomb && it_k.GetShipClass() == kShipClassAF) continue;
 		alived_list.push_back(ui);
 	}
-	if (alived_list.size() == 0) return -1;
-	return alived_list[rand_.RandInt(alived_list.size())];
+	const auto aliver_n = alived_list.size();
+	return { aliver_n, (aliver_n) ? alived_list[rand_.RandInt(alived_list.size())] : 0 };
 }
 template<typename CondFunc>
 bool any_of(const std::vector<std::vector<Kammusu>>& unit, CondFunc cond) noexcept {

--- a/KCS_CUI/source/fleet.hpp
+++ b/KCS_CUI/source/fleet.hpp
@@ -54,7 +54,7 @@ public:
 	double TrailerAircraftPlus();		//攻撃力補正を計算する
 	int AacType();					//発動する対空カットインの種類を判断する
 	int RandomKammusu();					//生存艦から艦娘をランダムに指定する
-	int RandomKammusuNonSS(const bool&);	//水上の生存艦から艦娘をランダムに指定する
+	std::pair<std::size_t, std::size_t> RandomKammusuNonSS(const bool&);	//水上の生存艦から艦娘をランダムに指定する
 };
 std::ostream& operator<<(std::ostream& os, const Fleet& conf);
 std::wostream& operator<<(std::wostream& os, const Fleet& conf);

--- a/KCS_CUI/source/main.cpp
+++ b/KCS_CUI/source/main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char *argv[]) {
 			fleet[i].Put();
 		}
 		// シミュレータを構築し、並列演算を行う
-		auto seed = make_SharedRand().generate_n<unsigned int>(config.GetThreads());
+		auto seed = make_SharedRand().make_unique_rand_array<unsigned int>(config.GetThreads());
 		vector<Result> result_db(config.GetTimes());
 #if defined(KCS_MEASURE_PROCESS_TIME)
 		const auto process_begin_time = std::chrono::high_resolution_clock::now();

--- a/KCS_CUI/source/random.cpp
+++ b/KCS_CUI/source/random.cpp
@@ -2,11 +2,11 @@
 #define NOMINMAX
 #endif
 #if defined(_WIN32) || defined(_WIN64)
-#if (!defined(_MSC_VER) || _MSC_VER >= 1400) && (!defined(DISABE_CRT_RAND_S))//Visual Studio 2005よりrand_sは実装された
-#define _CRT_RAND_S
-#endif //_MSC_VER >= 1400
-#define MY_ARC_FOR_WINDWOS 1
-#include <Windows.h>
+#	if (!defined(_MSC_VER) || _MSC_VER >= 1400) && (!defined(DISABE_CRT_RAND_S))//Visual Studio 2005よりrand_sは実装された
+#		define _CRT_RAND_S
+#	endif //_MSC_VER >= 1400
+#	define MY_ARC_FOR_WINDWOS 1
+#	include <Windows.h>
 #endif // defined(_WIN32) || defined(_WIN64)
 #include "random.hpp"
 #include <stdlib.h> //rand_s, malloc
@@ -15,18 +15,18 @@
 #include <functional>//std::ref in gcc
 #include <chrono>
 #if !defined(_MSC_VER) || !defined(__clang__)
-#ifndef __INTEL_COMPILER
-#include <immintrin.h>
-#if defined(_WIN32) || defined(_WIN64)
-#include <intrin.h>
-#else
-#include <x86intrin.h>
-#endif //defined(_WIN32) || defined(_WIN64)
-#ifdef __GNUC__
-#include <cpuid.h>
-#endif //__GNUC__
-#endif //__INTEL_COMPILER
-#include <cstring>
+#	ifndef __INTEL_COMPILER
+#		include <immintrin.h>
+#		if defined(_WIN32) || defined(_WIN64)
+#		include <intrin.h>
+#		else
+#			include <x86intrin.h>
+#		endif //defined(_WIN32) || defined(_WIN64)
+#		ifdef __GNUC__
+#			include <cpuid.h>
+#		endif //__GNUC__
+#	endif //__INTEL_COMPILER
+#	include <cstring>
 // Defines the bit mask used to examine the ecx register returned by cpuid.
 // (The 30th bit is set.)
 using std::uint32_t;
@@ -37,11 +37,11 @@ namespace intrin {
 	regs_t get_cpuid(unsigned int level) {
 		regs_t re = { 0 };
 		static_assert(sizeof(re) == (sizeof(uint32_t) * 4), "illegal size of struct regs_t ");
-#if ( defined(__INTEL_COMPILER) || defined(_MSC_VER) )
+#	if ( defined(__INTEL_COMPILER) || defined(_MSC_VER) )
 		__cpuid(reinterpret_cast<int*>(&re), static_cast<int>(level));
-#elif defined(__GNUC__)
+#	elif defined(__GNUC__)
 		__get_cpuid(level, &re.EAX, &re.EBX, &re.ECX, &re.EDX);//error: '__get_cpuid' was not declared in this scope
-#endif
+#	endif
 		return re;
 	}
 	bool IsIntelCPU() {
@@ -66,11 +66,11 @@ seed_v_t create_seed_v() {
 	if (intrin::IsRDRANDsupport()) {//RDRAND命令の結果もベクターに追加
 		for (std::size_t i = 0; i < 4; i++) {
 			unsigned int rdrand_value = 0;
-#ifndef __GNUC__
+#	if defined(_MSC_VER) || defined(__INTEL_COMPILER)
 			_rdrand32_step(&rdrand_value);
-#else//__GNUC__
+#	else//defined(_MSC_VER) || defined(__INTEL_COMPILER)
 			__builtin_ia32_rdrand32_step(&rdrand_value);
-#endif//__GNUC__
+#	endif//defined(_MSC_VER) || defined(__INTEL_COMPILER)
 			if (0 != rdrand_value) {
 				sed_v.push_back(rdrand_value & i);
 			}

--- a/KCS_CUI/source/random.hpp
+++ b/KCS_CUI/source/random.hpp
@@ -169,8 +169,9 @@ private:
 	}
 public:
 	template<typename RandType, std::enable_if_t<std::is_integral<RandType>::value/*std::is_arithmetic<RandType>::value*/, std::nullptr_t> = nullptr>
-	std::vector<RandType> make_unique_rand_array(const std::size_t size, RandType rand_min, RandType rand_max) {
+	std::vector<RandType> make_unique_rand_array(const std::size_t size, RandType rand_min = std::numeric_limits<RandType>::min(), RandType rand_max = std::numeric_limits<RandType>::max()) {
 		if (rand_min > rand_max) std::swap(rand_min, rand_max);
+		if (1 == size) return{ this->generate(rand_min, rand_max) };
 		const auto max_min_diff = detail::diff(rand_max, rand_min) + 1;
 		INVAID_ARGUMENT_THROW_WITH_MESSAGE_IF(max_min_diff < size, "random generate range(" + std::to_string(rand_min) + "-->" + std::to_string(rand_max) + ") is small to make unique rand array.")
 
@@ -183,7 +184,7 @@ public:
 		}
 	}
 	template<typename ForwardIte, typename RandType, std::enable_if_t<std::is_arithmetic<RandType>::value, std::nullptr_t> = nullptr>
-	void generate(ForwardIte begin, ForwardIte end, RandType rand_min, RandType rand_max) {
+	void generate(ForwardIte begin, ForwardIte end, RandType rand_min = std::numeric_limits<RandType>::min(), RandType rand_max = std::numeric_limits<RandType>::max()) {
 		if (rand_min > rand_max) std::swap(rand_min, rand_max);
 		auto& engine = this->get();
 		distribution_t<RandType> distribution(rand_min, rand_max);

--- a/KCS_CUI/source/simulator.hpp
+++ b/KCS_CUI/source/simulator.hpp
@@ -19,7 +19,7 @@ enum TorpedoTurn : std::uint8_t { kTorpedoFirst, kTorpedoSecond };
 // 砲撃戦の巡目(1巡目および2巡目)
 enum FireTurn { kFireFirst , kFireSecond };
 
-typedef vector<int> KammusuIndex;
+typedef vector<std::size_t> KammusuIndex;
 
 class Fleet;
 #include "result.hpp"


### PR DESCRIPTION
- KammusuIndexの定義を変更(`std::vector<int>`->`std::vector<std::size_t>`)
- 適切にstd::moveを使用
- seed生成がuniqueでなかったバグを修正
- signed->unsignedの変換を減らす
