### PR TITLE
seed生成の改善

### DIFF
--- a/KCS_CUI/source/base.hpp
+++ b/KCS_CUI/source/base.hpp
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <type_traits>
 #include "exception.hpp"
 #include "arithmetic_convert.hpp"
 #pragma warning( disable : 4592)
@@ -67,13 +68,13 @@ constexpr double LimitCap(const double &val, const double &val_cap) {
 }
 
 namespace detail {
-	struct to_i_helper {};
-	template<typename CharType>
-	inline int operator|(const std::basic_string<CharType>& str, to_i_helper) {
+	template<typename T, std::enable_if_t<std::is_arithmetic<T>::value, std::nullptr_t> = nullptr> struct to_i_helper {};
+	template<typename CharType, typename T>
+	inline int operator|(const std::basic_string<CharType>& str, to_i_helper<T>) {
 		return atithmetic_cvt::from_str<int>(str);
 	}
-	template<typename CharType>
-	inline int operator|(const CharType* str, to_i_helper) {
+	template<typename CharType, typename T>
+	inline T operator|(const CharType* str, to_i_helper<T>) {
 		return atithmetic_cvt::from_str<int>(std::basic_string<CharType>(str));
 	}
 	template<typename T>
@@ -87,6 +88,8 @@ namespace detail {
 		return (val < info.min) ? info.min : (info.max < val) ? info.max : val;
 	}
 }
-inline detail::to_i_helper to_i() noexcept { return{}; }
+inline detail::to_i_helper<int> to_i() noexcept { return{}; }
+inline detail::to_i_helper<size_t> to_sz() noexcept { return{}; }
+
 template<typename T>
 inline constexpr detail::limit_helper<T> limit(const T &val_min, const T &val_max) noexcept { return{ val_min, val_max }; }

--- a/KCS_CUI/source/config.cpp
+++ b/KCS_CUI/source/config.cpp
@@ -16,8 +16,8 @@ struct ForConfigImpl {
 	ForConfigImpl() : input_filename_(), formation_({{ kFormationTrail , kFormationTrail }}), times_(1), threads_(1), json_prettify_flg_(true) {}
 	std::array<string, kBattleSize> input_filename_;	//入力ファイル名
 	std::array<Formation, kBattleSize> formation_;		//陣形指定
-	int times_;		//試行回数
-	int threads_;	//スレッド数
+	size_t times_;		//試行回数
+	size_t threads_;	//スレッド数
 	string output_filename_;	//出力ファイル名
 	bool json_prettify_flg_;	//出力ファイルを整形するか
 };
@@ -66,10 +66,10 @@ namespace detail {
 		};
 		unordered_map<string, function<void(const char*)>> case_one_arg = {
 			{ "-n", [&re](const char*arg) {
-				re.times_ = std::max(1, arg | to_i());
+				re.times_ = std::max<size_t>(1, arg | to_sz());
 			}},
 			{ "-t", [&re](const char*arg) {
-				re.threads_ = std::max(1, arg | to_i());
+				re.threads_ = std::max<size_t>(1, arg | to_sz());
 			}},
 			{ "-o", [&re](const char*arg) {
 				re.output_filename_ = arg;
@@ -149,9 +149,15 @@ std::wstring Config::GetInputFilenameW(const int n) const
 
 Formation Config::GetFormation(const size_t n) const noexcept { return this->pimpl->e.formation_[n]; }
 
-int Config::GetTimes() const noexcept { return this->pimpl->e.times_; }
+size_t Config::GetTimes() const noexcept { return this->pimpl->e.times_; }
 
-int Config::GetThreads() const noexcept { return this->pimpl->e.threads_; }
+size_t Config::GetThreads() const noexcept { return this->pimpl->e.threads_; }
+
+#if defined(_OPENMP)
+size_t Config::CalcSeedArrSize() const noexcept { return GetTimes() * GetThreads(); }
+#else
+size_t Config::CalcSeedArrSize() const noexcept { return GetTimes(); }
+#endif
 
 const string & Config::GetOutputFilename() noexcept { return this->pimpl->e.output_filename_; }
 

--- a/KCS_CUI/source/config.hpp
+++ b/KCS_CUI/source/config.hpp
@@ -22,8 +22,9 @@ public:
 	const string& GetInputFilename(const size_t n) const noexcept;
 	std::wstring GetInputFilenameW(const int n) const;
 	Formation GetFormation(const size_t n) const noexcept;
-	int GetTimes() const noexcept;
-	int GetThreads() const noexcept;
+	size_t GetTimes() const noexcept;
+	size_t GetThreads() const noexcept;
+	size_t CalcSeedArrSize() const noexcept;
 	const string& GetOutputFilename() noexcept;
 	bool GetJsonPrettifyFlg() const noexcept;
 	//

--- a/KCS_CUI/source/other.cpp
+++ b/KCS_CUI/source/other.cpp
@@ -43,7 +43,7 @@ namespace detail {
 detail::Split_helper Split(char delim) noexcept { return{ delim }; }
 namespace detail {
 	// 文字列配列を数字配列に変換する
-	inline vector<int> operator|(const vector<string> &arr_str, to_i_helper) {
+	inline vector<int> operator|(const vector<string> &arr_str, to_i_helper<int>) {
 		vector<int> arr_int;
 		for (auto &it : arr_str) {
 			arr_int.push_back(it | to_i());


### PR DESCRIPTION
https://github.com/YSRKEN/KanColleSimulator_KAI/commit/0a559aa3de1e7702a171fa477abd814ce91be1d6
で書いたことを実行した。

Simulatorクラスに渡すseedはスレッド、試行回数によって被ってはいけない。そのためには事前にスレッド数×試行回数分のuniqueな乱数配列を作成する必要があると考える(私がなにか見落としていなければ)
