### PR TITLE
Air into weapon

### DIFF
--- a/KCS_CUI/source/fleet.cpp
+++ b/KCS_CUI/source/fleet.cpp
@@ -277,9 +277,9 @@ int Fleet::AntiAirScore() const noexcept {
 	int anti_air_score = 0;
 	for (auto &it_k : FirstUnit()) {
 		if (it_k.Status() == kStatusLost) continue;
-		for (size_t wi = 0; wi < it_k.GetSlots(); ++wi) {
-			if (!it_k.GetWeapon()[wi].Is(WeaponClass::AirFight)) continue;
-			anti_air_score += it_k.GetWeapon()[wi].AntiAirScore(it_k.GetAir()[wi]);
+		for (const auto& it_w : it_k.GetWeapon()) {
+			if (!it_w.Is(WeaponClass::AirFight)) continue;
+			anti_air_score += it_w.AntiAirScore(it_w.GetAir());
 		}
 	}
 	return anti_air_score;
@@ -291,10 +291,9 @@ double Fleet::TrailerAircraftProb(const AirWarStatus &air_war_status) const {
 	double trailer_aircraft_prob = 0.0;
 	for (auto &it_k : FirstUnit()) {
 		if (it_k.Status() == kStatusLost) continue;
-		for (size_t wi = 0; wi < it_k.GetSlots(); ++wi) {
-			auto it_w = it_k.GetWeapon()[wi];
+		for (const auto& it_w : it_k.GetWeapon()) {
 			if (it_w.Is(WeaponClass::PS | WeaponClass::PSS | WeaponClass::DaiteiChan | WeaponClass::WS | WeaponClass::WSN))
-				trailer_aircraft_prob += 0.04 * it_w.GetSearch() * sqrt(it_k.GetAir()[wi]);
+				trailer_aircraft_prob += 0.04 * it_w.GetSearch() * sqrt(it_w.GetAir());
 		}
 	}
 	// 制空段階によって補正を掛ける(航空優勢以外は試験実装)

--- a/KCS_CUI/source/kammusu.cpp
+++ b/KCS_CUI/source/kammusu.cpp
@@ -92,8 +92,6 @@ int Kammusu::GetSearch() const noexcept { return search_; }
 bool Kammusu::IsKammusu() const noexcept { return kammusu_flg_; }
 int Kammusu::GetLevel() const noexcept { return level_; }
 int Kammusu::GetHP() const noexcept { return hp_; }
-vector<int>& Kammusu::GetAir() noexcept { return airs_; }
-const vector<int>& Kammusu::GetAir() const noexcept { return airs_; }
 vector<Weapon>& Kammusu::GetWeapon() noexcept { return weapons_; }
 const vector<Weapon>& Kammusu::GetWeapon() const noexcept { return weapons_; }
 int Kammusu::GetAmmo() const noexcept { return ammo_; }
@@ -105,7 +103,7 @@ void Kammusu::SetAntiSub(const int anti_sub) noexcept { anti_sub_ = anti_sub; }
 void Kammusu::SetSearch(const int search) noexcept { search_ = search; }
 void Kammusu::SetLevel(const int level) noexcept { level_ = level; }
 void Kammusu::SetHP(const int hp) noexcept { hp_ = hp; }
-void Kammusu::SetWeapon(const size_t index, const Weapon & weapon) { weapons_[index] = weapon; }
+void Kammusu::SetWeapon(const size_t index, const Weapon & weapon) { weapons_[index] = weapon; weapons_[index].SetAir(max_airs_[index]); }
 void Kammusu::SetCond(const int cond) noexcept { cond_ = cond; }
 
 // 中身を表示する
@@ -121,8 +119,7 @@ wstring Kammusu::GetNameLv() const {
 // 変更可な部分をリセットする(装備なし)
 Kammusu Kammusu::Reset() {
 	hp_ = max_hp_;
-	airs_ = max_airs_;
-	weapons_.resize(slots_, Weapon());
+	weapons_ = std::vector<Weapon>(slots_, Weapon());
 	cond_ = 49;
 	ammo_ = 100;
 	fuel_ = 100;
@@ -133,6 +130,7 @@ Kammusu Kammusu::Reset(const WeaponDB &weapon_db) {
 	this->Reset();
 	for (size_t i = 0; i < slots_; ++i) {
 		weapons_[i] = weapon_db.Get(first_weapons_[i], std::nothrow);
+		weapons_[i].SetAir(max_airs_[i]);
 	}
 	return *this;
 }
@@ -780,8 +778,8 @@ void Kammusu::ChangeCond(const int cond_change) noexcept {
 }
 
 bool Kammusu::HasWeaponClass(const WeaponClass& wc) const noexcept {
-	for (size_t i = 0; i < slots_; ++i) {
-		if (weapons_[i].Is(wc) && airs_[i] > 0) return true;
+	for (const auto& it_w : weapons_) {
+		if (it_w.Is(wc) && it_w.GetAir() > 0) return true;
 	}
 	return false;
 }
@@ -958,21 +956,11 @@ bool Kammusu::IsFireGunPlane() const noexcept {
 }
 
 bool Kammusu::IsAntiSubDayPlane() const noexcept {
-	for (size_t wi = 0; wi < slots_; ++wi) {
-		if (airs_[wi] == 0) continue;
-		if (weapons_[wi].Is(WeaponClass::PBF | WeaponClass::PB | WeaponClass::PA))
-			return true;
-	}
-	return false;
+	return HasWeaponClass(WeaponClass::PBF | WeaponClass::PB | WeaponClass::PA);
 }
 
 bool Kammusu::IsAntiSubDayWater() const noexcept {
-	for (size_t wi = 0; wi < slots_; ++wi) {
-		if (airs_[wi] == 0) continue;
-		if (weapons_[wi].Is(WeaponClass::WB | WeaponClass::ASPP | WeaponClass::AJ))
-			return true;
-	}
-	return false;
+	return HasWeaponClass(WeaponClass::WB | WeaponClass::ASPP | WeaponClass::AJ);
 }
 
 // 夜戦で攻撃可能な艦ならtrue
@@ -1030,7 +1018,7 @@ std::ostream & operator<<(std::ostream & os, const Kammusu & conf)
 		<< "　装備：";
 	for (size_t i = 0; i < conf.slots_; ++i) {
 		if (i != 0) os << ",";
-		os << char_cvt::utf_16_to_shift_jis(conf.weapons_[i].GetName()) << "(" << conf.airs_[i] << ")";
+		os << char_cvt::utf_16_to_shift_jis(conf.weapons_[i].GetName()) << "(" << conf.weapons_[i].GetAir() << ")";
 	}
 	os 
 		<< endl
@@ -1056,7 +1044,7 @@ std::wostream & operator<<(std::wostream & os, const Kammusu & conf)
 		<< L"　装備：";
 	for (size_t i = 0; i < conf.slots_; ++i) {
 		if (i != 0) os << ",";
-		os << conf.weapons_[i].GetName() << L"(" << conf.airs_[i] << ")";
+		os << conf.weapons_[i].GetName() << L"(" << conf.weapons_[i].GetAir() << ")";
 	}
 	os
 		<< endl

--- a/KCS_CUI/source/kammusu.hpp
+++ b/KCS_CUI/source/kammusu.hpp
@@ -81,7 +81,6 @@ class Kammusu {
 	SharedRand rand_;
 	// 変更するもの
 	int hp_;					//現耐久
-	vector<int> airs_;			//現搭載数
 	vector<Weapon> weapons_;	//現装備
 	int cond_;					//cond値
 	int ammo_;					//残弾薬割合
@@ -120,8 +119,6 @@ public:
 	bool IsKammusu() const noexcept;
 	int GetLevel() const noexcept;
 	int GetHP() const noexcept;
-	vector<int>& GetAir() noexcept;
-	const vector<int>& GetAir() const noexcept;
 	vector<Weapon>& GetWeapon() noexcept;
 	const vector<Weapon>& GetWeapon() const noexcept;
 	int GetAmmo() const noexcept;

--- a/KCS_CUI/source/other.cpp
+++ b/KCS_CUI/source/other.cpp
@@ -89,7 +89,7 @@ WeaponDB::WeaponDB(const char* csv_name) {
 		auto range        = static_cast<Range>(list[header.at("射程")] | to_i());
 		auto level        = 0;
 		auto level_detail = 0;
-		auto air          = -1;
+		auto air          = 0;
 		
 		hash_[id] = Weapon(
 			id, name, weapon_class, defense, attack, torpedo, bomb, anti_air,

--- a/KCS_CUI/source/other.cpp
+++ b/KCS_CUI/source/other.cpp
@@ -89,10 +89,11 @@ WeaponDB::WeaponDB(const char* csv_name) {
 		auto range        = static_cast<Range>(list[header.at("射程")] | to_i());
 		auto level        = 0;
 		auto level_detail = 0;
+		auto air          = -1;
 		
 		hash_[id] = Weapon(
 			id, name, weapon_class, defense, attack, torpedo, bomb, anti_air,
-			anti_sub, hit, evade, search, range, level, level_detail
+			anti_sub, hit, evade, search, range, level, level_detail, air
 		);
 	}
 	// ダミーデータを代入する

--- a/KCS_CUI/source/simulator.cpp
+++ b/KCS_CUI/source/simulator.cpp
@@ -345,8 +345,8 @@ void Simulator::AirWarPhase() {
 	cout << "残機：" << endl;
 	for (size_t i = 0; i < kBattleSize; ++i) {
 		for (auto &it_k : fleet_[i].FirstUnit()) {
-			for (size_t wi = 0; wi < it_k.GetSlots(); ++wi) {
-				cout << it_k.GetAir()[wi] << " ";
+			for (const auto& it_w : it_k.GetWeapon()) {
+				cout << it_w.GetAir() << " ";
 			}
 			cout << endl;
 		}

--- a/KCS_CUI/source/simulator.cpp
+++ b/KCS_CUI/source/simulator.cpp
@@ -223,10 +223,9 @@ void Simulator::AirWarPhase() {
 	for (size_t i = 0; i < kBattleSize; ++i) {
 		for (auto &it_k : fleet_[i].FirstUnit()) {
 			if (it_k.Status() == kStatusLost) continue;
-			for (size_t wi = 0; wi < it_k.GetSlots(); ++wi) {
-				auto &it_w = it_k.GetWeapon()[wi];
+			for (auto& it_w : it_k.GetWeapon()) {
 				if (!it_w.Is(WeaponClass::AirFight)) continue;
-				it_k.GetAir()[wi] -= int(it_k.GetAir()[wi] * killed_airs_per[i]);
+				it_w.SetAir(it_w.GetAir() - int(it_w.GetAir() * killed_airs_per[i]));
 			}
 		}
 	}
@@ -244,8 +243,7 @@ void Simulator::AirWarPhase() {
 		auto other_side = kBattleSize - i - 1;	//自分にとっての敵、敵にとっての自分
 		for (auto &it_k : fleet_[other_side].FirstUnit()) {
 			if (it_k.Status() == kStatusLost) continue;
-			for (size_t wi = 0; wi < it_k.GetSlots(); ++wi) {
-				auto &it_w = it_k.GetWeapon()[wi];
+			for (auto& it_w : it_k.GetWeapon()) {
 				if (!it_w.Is(WeaponClass::AirFight)) continue;
 				auto intercept_index = fleet_[i].RandomKammusu();
 				if (!std::get<0>(intercept_index)) continue;
@@ -273,17 +271,17 @@ void Simulator::AirWarPhase() {
 					}
 				}
 				//割合撃墜
-				if (rand.RandBool()) killed_airs += int(int(0.9 * all_anti_air) * it_k.GetAir()[wi] / 360);
+				if (rand.RandBool()) killed_airs += int(int(0.9 * all_anti_air) * it_w.GetAir() / 360);
 				//対空カットイン成功時の固定ボーナス
 				killed_airs += aac_bonus_add1[aac_type];
 				//艦娘限定ボーナス
 				if (intercept_kammusu.IsKammusu()) killed_airs += 1;
 				//撃墜処理
-				if (it_k.GetAir()[wi] > killed_airs) {
-					it_k.GetAir()[wi] -= killed_airs;
+				if (it_w.GetAir() > killed_airs) {
+					it_w.SetAir(it_w.GetAir() - killed_airs);
 				}
 				else {
-					it_k.GetAir()[wi] = 0;
+					it_w.SetAir(0);
 				}
 			}
 		}
@@ -297,29 +295,28 @@ void Simulator::AirWarPhase() {
 		auto &friend_unit = fleet_[bi].FirstUnit();
 		for (size_t ui = 0; ui < friend_unit.size(); ++ui) {
 			auto &hunter_kammusu = friend_unit[ui];
-			auto &friend_weapon = hunter_kammusu.GetWeapon();
 			// 既に沈んでいる場合は攻撃できない
 			if (hunter_kammusu.Status() == kStatusLost) continue;
 			// 敵に攻撃できない場合は次の艦娘にバトンタッチ
 			auto has_attacker = fleet_[other_side].RandomKammusuNonSS(false, kTargetTypeAll);
 			if (!std::get<0>(has_attacker)) continue;
 			// そうでない場合は、各スロットに対して攻撃対象を選択する
-			for (size_t wi = 0; wi < hunter_kammusu.GetSlots(); ++wi) {
-				if (hunter_kammusu.GetAir()[wi] == 0 || !friend_weapon[wi].Is(WeaponClass::AirBomb)) continue;
+			for (const auto& it_w : hunter_kammusu.GetWeapon()) {
+				if (it_w.GetAir() == 0 || !it_w.Is(WeaponClass::AirBomb)) continue;
 				// 爆撃する対象を決定する(各スロット毎に、ランダムに対象を選択しなければならない)
 				auto target = std::get<1>(fleet_[other_side].RandomKammusuNonSS(false, kTargetTypeAll));
 				// 基礎攻撃力を算出する
 				int base_attack;
-				switch (friend_weapon[wi].GetWeaponClass()) {
+				switch (it_w.GetWeaponClass()) {
 				case WeaponClass::PBF:
 				case WeaponClass::PB:
 				case WeaponClass::WB:
 					// 爆撃は等倍ダメージ
-					base_attack = int(friend_weapon[wi].GetBomb() * sqrt(hunter_kammusu.GetAir()[wi]) + 25);
+					base_attack = int(it_w.GetBomb() * sqrt(it_w.GetAir()) + 25);
 					break;
 				case WeaponClass::PA:
 					// 雷撃は150％か80％かがランダムで決まる
-					base_attack = int((rand.RandBool() ? 1.5 : 0.8) * (friend_weapon[wi].GetTorpedo() * sqrt(hunter_kammusu.GetAir()[wi]) + 25));
+					base_attack = int((rand.RandBool() ? 1.5 : 0.8) * (it_w.GetTorpedo() * sqrt(it_w.GetAir()) + 25));
 					break;
 				default:
 					base_attack = 0;

--- a/KCS_CUI/source/weapon.cpp
+++ b/KCS_CUI/source/weapon.cpp
@@ -2,7 +2,7 @@
 #include "weapon.hpp"
 #include "char_convert.hpp"
 // コンストラクタ
-Weapon::Weapon() noexcept : Weapon(-1, {}, WeaponClass::Other, 0, 0, 0, 0, 0, 0, 0, 0, 0, kRangeNone, 0, 0, -1) {}
+Weapon::Weapon() noexcept : Weapon(-1, {}, WeaponClass::Other, 0, 0, 0, 0, 0, 0, 0, 0, 0, kRangeNone, 0, 0, 0) {}
 Weapon::Weapon(
 	const int id, wstring name, const WeaponClass weapon_class, const int defense,
 	const int attack, const int torpedo, const int bomb, const int anti_air, const int anti_sub,

--- a/KCS_CUI/source/weapon.cpp
+++ b/KCS_CUI/source/weapon.cpp
@@ -2,14 +2,14 @@
 #include "weapon.hpp"
 #include "char_convert.hpp"
 // コンストラクタ
-Weapon::Weapon() noexcept : Weapon(-1, {}, WeaponClass::Other, 0, 0, 0, 0, 0, 0, 0, 0, 0, kRangeNone, 0, 0) {}
+Weapon::Weapon() noexcept : Weapon(-1, {}, WeaponClass::Other, 0, 0, 0, 0, 0, 0, 0, 0, 0, kRangeNone, 0, 0, -1) {}
 Weapon::Weapon(
 	const int id, wstring name, const WeaponClass weapon_class, const int defense,
 	const int attack, const int torpedo, const int bomb, const int anti_air, const int anti_sub,
-	const int hit, const int evade, const int search, const Range range, const int level, const int level_detail) noexcept :
+	const int hit, const int evade, const int search, const Range range, const int level, const int level_detail, const int air) noexcept :
 	id_(id), name_(move(name)), weapon_class_(weapon_class), defense_(defense), attack_(attack),
 	torpedo_(torpedo), bomb_(bomb), anti_air_(anti_air), anti_sub_(anti_sub), hit_(hit),
-	evade_(evade), search_(search), range_(range), level_(level), level_detail_(level_detail) {}
+	evade_(evade), search_(search), range_(range), level_(level), level_detail_(level_detail), air_(air) {}
 
 // getter
 int Weapon::GetID() const noexcept { return id_; }
@@ -26,9 +26,11 @@ int Weapon::GetEvade() const noexcept { return evade_; }
 int Weapon::GetSearch() const noexcept { return search_; }
 Range Weapon::GetRange() const noexcept { return range_; }
 int Weapon::GetLevel() const noexcept { return level_; }
+int Weapon::GetAir() const noexcept { return air_; }
 // setter
 void Weapon::SetLevel(const int level) { level_ = level; }
 void Weapon::SetLevelDetail(const int level_detail) { level_detail_ = level_detail; }
+void Weapon::SetAir(const int air) { air_ = air; }
 
 // 中身を表示する
 void Weapon::Put() const {

--- a/KCS_CUI/source/weapon.hpp
+++ b/KCS_CUI/source/weapon.hpp
@@ -62,12 +62,13 @@ class Weapon {
 	Range range_;				//射程
 	int level_;					//装備改修度(0-10)、外部熟練度(0-7)
 	int level_detail_;			//内部熟練度(0-120)
+	int air_;					//現搭載数
 public:
 	// コンストラクタ
 	Weapon() noexcept;
 	Weapon(
 		const int, wstring, const WeaponClass, const int, const int, const int, const int,
-		const int, const int, const int, const int, const int, const Range, const int, const int) noexcept;
+		const int, const int, const int, const int, const int, const Range, const int, const int, const int) noexcept;
 	// getter
 	int GetID() const noexcept;
 	const std::wstring& GetName() const noexcept;
@@ -83,9 +84,11 @@ public:
 	int GetSearch() const noexcept;
 	Range GetRange() const noexcept;
 	int GetLevel() const noexcept;
+	int GetAir() const noexcept;
 	// setter
 	void SetLevel(const int level);
 	void SetLevelDetail(const int level_detail);
+	void SetAir(const int air);
 	// その他
 	void Put() const;					//中身を表示する
 	int AntiAirScore(const int&) const noexcept;	//制空値を計算する


### PR DESCRIPTION
Kammusu::airs_（現搭載機数）はKammusu::weapons_（現装備）と同時にしか使われていないので、Weaponクラスへ移動するのはどうでしょうか？
これによりindex based forにせざるを得なかった部分もrange based forにリファクタできます。
