### PR TITLE
Resultのvectorをarrayへ変更

### DIFF
--- a/KCS_CUI/source/result.cpp
+++ b/KCS_CUI/source/result.cpp
@@ -1,13 +1,6 @@
 ﻿#include "base.hpp"
 #include "result.hpp"
 #include <array>
-// コンストラクタ
-Result::Result() {
-	hp_before_.resize(kBattleSize, vector<vector<int>>(kMaxFleetSize, vector<int>(kMaxUnitSize)));
-	hp_.resize(kBattleSize, vector<vector<int>>(kMaxFleetSize, vector<int>(kMaxUnitSize)));
-	damage_.resize(kBattleSize, vector<vector<int>>(kMaxFleetSize, vector<int>(kMaxUnitSize, 0)));
-	damage_night_.resize(kBattleSize, vector<vector<int>>(kMaxFleetSize, vector<int>(kMaxUnitSize, 0)));
-}
 
 // getter
 int Result::GetHP(const size_t bi, const size_t fi, const size_t ui) const noexcept { return hp_[bi][fi][ui]; }

--- a/KCS_CUI/source/result.hpp
+++ b/KCS_CUI/source/result.hpp
@@ -17,14 +17,14 @@ const wstring kWinReasonStrL[] = { L"完全勝利SS", L"勝利S", L"勝利A", L"
 const string kWinReasonStrS[] = { "SS", "S", "A", "B", "C", "D", "E" };
 
 class Result {
-	vector<vector<vector<int>>> hp_before_;
-	vector<vector<vector<int>>> hp_;
-	vector<vector<vector<int>>> damage_;
-	vector<vector<vector<int>>> damage_night_;
+	std::array<std::array<std::array<int, kMaxUnitSize>, kMaxFleetSize>, kBattleSize> hp_before_ = {};
+	std::array<std::array<std::array<int, kMaxUnitSize>, kMaxFleetSize>, kBattleSize> hp_ = {};
+	std::array<std::array<std::array<int, kMaxUnitSize>, kMaxFleetSize>, kBattleSize> damage_ = {};
+	std::array<std::array<std::array<int, kMaxUnitSize>, kMaxFleetSize>, kBattleSize> damage_night_ = {};
 	bool night_flg_;
 public:
 	// コンストラクタ
-	Result();
+	Result() {}
 	// getter
 	int GetHP(const size_t bi, const size_t fi, const size_t ui) const noexcept;
 	int GetDamage(const size_t bi, const size_t fi, const size_t ui, const bool special_mvp_flg = false) const noexcept;


### PR DESCRIPTION
固定長の３次元vectorをarrayへ変更することで、new / deleteを削減する。`-n 10000`シミュレーションで

| Function | Before | After |
| --- | --- | --- |
| std::_Allocate | 11,771,557 | 6,896,923 |
| operator new | 11,791,879 | 6,917,245 |
| free | 11,791,879 | 6,917,245 |
| std::vector<int>::.ctor(copy) | 4,571,932 | 37,932 |

の削減で、実行時間も20%ほど高速化（プロファイルでの測定だが152秒→122秒）。
