### PR TITLE
fix double double-quoted string.

### DIFF
--- a/KCS_CUI/source/weapon.cpp
+++ b/KCS_CUI/source/weapon.cpp
@@ -10,7 +10,7 @@ constexpr WeaponClass ToWC(const cstring<wchar_t>& str) noexcept {
 
 const std::unordered_map<int, const Weapon> Weapon::db_ = {
 #define WEAPON(PREFIX, ID, NAME, WEAPON_CLASS, DEFENSE, ATTACK, TORPEDO, BOMB, ANTI_AIR, ANTI_SUB, HIT, EVADE, SEARCH, RANGE, POSTFIX)	\
-	{ ID, { ID, L ## #NAME ## s, std::integral_constant<WeaponClass, ToWC(L ## #WEAPON_CLASS ## _cs)>{}(),								\
+	{ ID, { ID, L ## NAME ## s, std::integral_constant<WeaponClass, ToWC(L ## WEAPON_CLASS ## _cs)>{}(),								\
 			DEFENSE, ATTACK, TORPEDO, BOMB, ANTI_AIR, ANTI_SUB, HIT, EVADE, SEARCH, static_cast<Range>(RANGE), 0, 0, 0 } },
 #include "slotitems.csv"
 #undef WEAPON


### PR DESCRIPTION
#61 でcsv内の文字列を "" で括りましたが、プリプロセッサマクロでも "" で括る処理が残っていたため

```
"\"主砲\""
```

という文字列が生成され、その後の装備種別検索に失敗していました。

その他、装備名についても同様の問題がありました。こちらは実行時に参照されていないため埋もれていました。艦名、艦種については #61 時に正しく反映済みでした。
