### PR TITLE
fix wrong field name.

### DIFF
--- a/KCS_GUI/Form1.cs
+++ b/KCS_GUI/Form1.cs
@@ -1320,7 +1320,7 @@ namespace KCS_GUI {
 							}
 							if(RfWeaponTypeList.IndexOf(setWeaponType) != -1) {
 								setWeapon["rf"] = unit[fi][si].weapon[wi].rf;
-								setWeapon["detail_rf"] = unit[fi][si].weapon[wi].detailRf;
+								setWeapon["rf_detail"] = unit[fi][si].weapon[wi].detailRf;
 							} else {
 								setWeapon["rf"] = unit[fi][si].weapon[wi].level;
 							}


### PR DESCRIPTION
間違ったフィールド名でJSONを生成するので、正確なシミュレーションが行えない。
