### PR TITLE
Use data bind

### DIFF
--- a/KCS_GUI/CsvDataSet.cs
+++ b/KCS_GUI/CsvDataSet.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+
+namespace KCS_GUI {
+	partial class CsvDataSet {
+		// 装備・艦娘データ
+		internal static readonly CsvDataSet data = new CsvDataSet();
+		//種別→種別番号変換
+		internal static readonly Dictionary<string, int> WeaponTypeToNumber = new Dictionary<string, int> {
+			{"主砲",0},
+			{"対艦強化弾",1},
+			{"副砲",2},
+			{"魚雷",3},
+			{"特殊潜航艇",4},
+			{"艦上戦闘機",5},
+			{"艦上爆撃機",6},
+			{"艦上爆撃機(爆戦)",7},
+			{"水上爆撃機",8},
+			{"艦上攻撃機",9},
+			{"艦上偵察機",10},
+			{"艦上偵察機(彩雲)",11},
+			{"大型飛行艇",12},
+			{"水上偵察機",13},
+			{"水上偵察機(夜偵)",14},
+			{"対潜哨戒機",15},
+			{"オートジャイロ",16},
+			{"小型電探",17},
+			{"大型電探",18},
+			{"対空機銃",19},
+			{"対空強化弾",20},
+			{"高射装置",21},
+			{"爆雷",22},
+			{"ソナー",23},
+			{"応急修理要員",24},
+			{"探照灯",25},
+			{"照明弾",26},
+			{"艦隊司令部施設",27},
+			{"水上艦要員",28},
+			{"戦闘糧食",29},
+			{"洋上補給",30},
+			{"水上戦闘機",31},
+			{"その他",32}
+		};
+		//熟練度が存在する装備の種別番号一覧
+		internal static readonly HashSet<int> RfWeaponTypeList = new HashSet<int> {
+			WeaponTypeToNumber["艦上戦闘機"],
+			WeaponTypeToNumber["艦上爆撃機"],
+			WeaponTypeToNumber["艦上爆撃機(爆戦)"],
+			WeaponTypeToNumber["水上爆撃機"],
+			WeaponTypeToNumber["艦上攻撃機"],
+			WeaponTypeToNumber["艦上偵察機"],
+			WeaponTypeToNumber["艦上偵察機(彩雲)"],
+			WeaponTypeToNumber["大型飛行艇"],
+			WeaponTypeToNumber["水上戦闘機"]
+		};
+		static CsvDataSet() {
+			using (var adapter = new CsvDataSetTableAdapters.ShipsTableAdapter())
+				adapter.Fill(data.Ships);
+			using (var adapter = new CsvDataSetTableAdapters.WeaponsTableAdapter())
+				adapter.Fill(data.Weapons);
+		}
+	}
+}

--- a/KCS_GUI/CsvDataSet.cs
+++ b/KCS_GUI/CsvDataSet.cs
@@ -4,6 +4,32 @@ namespace KCS_GUI {
 	partial class CsvDataSet {
 		// 装備・艦娘データ
 		internal static readonly CsvDataSet data = new CsvDataSet();
+
+		internal static readonly string[] shipTypes = {
+			"魚雷艇",
+			"駆逐艦",
+			"軽巡洋艦",
+			"重雷装巡洋艦",
+			"重巡洋艦",
+			"航空巡洋艦",
+			"軽空母",
+			"巡洋戦艦",
+			"戦艦",
+			"航空戦艦",
+			"正規空母",
+			"陸上型",
+			"潜水艦",
+			"潜水空母",
+			"輸送艦",
+			"水上機母艦",
+			"揚陸艦",
+			"装甲空母",
+			"工作艦",
+			"潜水母艦",
+			"練習巡洋艦",
+			"給油艦",
+		};
+
 		//種別→種別番号変換
 		internal static readonly Dictionary<string, int> WeaponTypeToNumber = new Dictionary<string, int> {
 			{"主砲",0},

--- a/KCS_GUI/Form1.Designer.cs
+++ b/KCS_GUI/Form1.Designer.cs
@@ -290,6 +290,7 @@
 			// 
 			// KammusuNameComboBox
 			// 
+			this.KammusuNameComboBox.DisplayMember = "艦名";
 			this.KammusuNameComboBox.FormattingEnabled = true;
 			this.KammusuNameComboBox.Location = new System.Drawing.Point(186, 105);
 			this.KammusuNameComboBox.Name = "KammusuNameComboBox";
@@ -659,34 +660,13 @@
 			// 
 			// KammusuTypeComboBox
 			// 
+			this.KammusuTypeComboBox.DisplayMember = "Key";
 			this.KammusuTypeComboBox.FormattingEnabled = true;
-			this.KammusuTypeComboBox.Items.AddRange(new object[] {
-            "魚雷艇",
-            "駆逐艦",
-            "軽巡洋艦",
-            "重雷装巡洋艦",
-            "重巡洋艦",
-            "航空巡洋艦",
-            "軽空母",
-            "巡洋戦艦",
-            "戦艦",
-            "航空戦艦",
-            "正規空母",
-            "陸上型",
-            "潜水艦",
-            "潜水空母",
-            "輸送艦",
-            "水上機母艦",
-            "揚陸艦",
-            "装甲空母",
-            "工作艦",
-            "潜水母艦",
-            "練習巡洋艦",
-            "給油艦"});
 			this.KammusuTypeComboBox.Location = new System.Drawing.Point(186, 80);
 			this.KammusuTypeComboBox.Name = "KammusuTypeComboBox";
 			this.KammusuTypeComboBox.Size = new System.Drawing.Size(100, 20);
 			this.KammusuTypeComboBox.TabIndex = 11;
+			this.KammusuTypeComboBox.ValueMember = "Value";
 			this.KammusuTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.KammusuTypeComboBox_SelectedIndexChanged);
 			// 
 			// label7

--- a/KCS_GUI/Form1.Designer.cs
+++ b/KCS_GUI/Form1.Designer.cs
@@ -916,6 +916,7 @@
 			// 
 			// MapKammusuNameComboBox
 			// 
+			this.MapKammusuNameComboBox.DisplayMember = "艦名";
 			this.MapKammusuNameComboBox.FormattingEnabled = true;
 			this.MapKammusuNameComboBox.Location = new System.Drawing.Point(239, 195);
 			this.MapKammusuNameComboBox.Name = "MapKammusuNameComboBox";
@@ -976,35 +977,14 @@
 			// 
 			// MapKammusuTypeComboBox
 			// 
+			this.MapKammusuTypeComboBox.DisplayMember = "Key";
 			this.MapKammusuTypeComboBox.FormattingEnabled = true;
-			this.MapKammusuTypeComboBox.Items.AddRange(new object[] {
-            "魚雷艇",
-            "駆逐艦",
-            "軽巡洋艦",
-            "重雷装巡洋艦",
-            "重巡洋艦",
-            "航空巡洋艦",
-            "軽空母",
-            "巡洋戦艦",
-            "戦艦",
-            "航空戦艦",
-            "正規空母",
-            "陸上型",
-            "潜水艦",
-            "潜水空母",
-            "輸送艦",
-            "水上機母艦",
-            "揚陸艦",
-            "装甲空母",
-            "工作艦",
-            "潜水母艦",
-            "練習巡洋艦",
-            "給油艦"});
 			this.MapKammusuTypeComboBox.Location = new System.Drawing.Point(239, 169);
 			this.MapKammusuTypeComboBox.Name = "MapKammusuTypeComboBox";
 			this.MapKammusuTypeComboBox.Size = new System.Drawing.Size(100, 20);
 			this.MapKammusuTypeComboBox.TabIndex = 32;
 			this.MapKammusuTypeComboBox.Text = "駆逐艦";
+			this.MapKammusuTypeComboBox.ValueMember = "Value";
 			this.MapKammusuTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.MapKammusuTypeComboBox_SelectedIndexChanged);
 			// 
 			// label25

--- a/KCS_GUI/Form1.Designer.cs
+++ b/KCS_GUI/Form1.Designer.cs
@@ -926,6 +926,7 @@
 			// 
 			// MapKammusuListBox
 			// 
+			this.MapKammusuListBox.DisplayMember = "艦名";
 			this.MapKammusuListBox.FormattingEnabled = true;
 			this.MapKammusuListBox.ItemHeight = 12;
 			this.MapKammusuListBox.Location = new System.Drawing.Point(78, 173);

--- a/KCS_GUI/Form1.Designer.cs
+++ b/KCS_GUI/Form1.Designer.cs
@@ -808,6 +808,7 @@
 			// 
 			// KammusuSelectListBox
 			// 
+			this.KammusuSelectListBox.DisplayMember = "艦名";
 			this.KammusuSelectListBox.FormattingEnabled = true;
 			this.KammusuSelectListBox.ItemHeight = 12;
 			this.KammusuSelectListBox.Location = new System.Drawing.Point(65, 83);

--- a/KCS_GUI/Form1.Designer.cs
+++ b/KCS_GUI/Form1.Designer.cs
@@ -625,6 +625,7 @@
 			// 
 			// WeaponSelectListBox
 			// 
+			this.WeaponSelectListBox.DisplayMember = "装備名";
 			this.WeaponSelectListBox.FormattingEnabled = true;
 			this.WeaponSelectListBox.ItemHeight = 12;
 			this.WeaponSelectListBox.Location = new System.Drawing.Point(65, 165);

--- a/KCS_GUI/Form1.Designer.cs
+++ b/KCS_GUI/Form1.Designer.cs
@@ -232,6 +232,7 @@
 			// 
 			// WeaponNameComboBox
 			// 
+			this.WeaponNameComboBox.DisplayMember = "装備名";
 			this.WeaponNameComboBox.FormattingEnabled = true;
 			this.WeaponNameComboBox.Location = new System.Drawing.Point(188, 187);
 			this.WeaponNameComboBox.Name = "WeaponNameComboBox";
@@ -573,45 +574,13 @@
 			// 
 			// WeaponTypeComboBox
 			// 
+			this.WeaponTypeComboBox.DisplayMember = "Key";
 			this.WeaponTypeComboBox.FormattingEnabled = true;
-			this.WeaponTypeComboBox.Items.AddRange(new object[] {
-            "主砲",
-            "対艦強化弾",
-            "副砲",
-            "魚雷",
-            "特殊潜航艇",
-            "艦上戦闘機",
-            "艦上爆撃機",
-            "艦上爆撃機(爆戦)",
-            "水上爆撃機",
-            "艦上攻撃機",
-            "艦上偵察機",
-            "艦上偵察機(彩雲)",
-            "大型飛行艇",
-            "水上偵察機",
-            "水上偵察機(夜偵)",
-            "対潜哨戒機",
-            "オートジャイロ",
-            "小型電探",
-            "大型電探",
-            "対空機銃",
-            "対空強化弾",
-            "高射装置",
-            "爆雷",
-            "ソナー",
-            "応急修理要員",
-            "探照灯",
-            "照明弾",
-            "艦隊司令部施設",
-            "水上艦要員",
-            "戦闘糧食",
-            "洋上補給",
-            "水上戦闘機",
-            "その他"});
 			this.WeaponTypeComboBox.Location = new System.Drawing.Point(188, 162);
 			this.WeaponTypeComboBox.Name = "WeaponTypeComboBox";
 			this.WeaponTypeComboBox.Size = new System.Drawing.Size(120, 20);
 			this.WeaponTypeComboBox.TabIndex = 21;
+			this.WeaponTypeComboBox.ValueMember = "Value";
 			this.WeaponTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.WeaponTypeComboBox_SelectedIndexChanged);
 			// 
 			// label11

--- a/KCS_GUI/Form1.cs
+++ b/KCS_GUI/Form1.cs
@@ -43,6 +43,11 @@ namespace KCS_GUI {
 		public MainForm() {
 			InitializeComponent();
 			try {
+				KammusuTypeComboBox.DataSource = data.Ships
+					.Where(s => s.艦種 < shipTypes.Length)
+					.OrderBy(s => s.艦種)
+					.GroupBy(s => s.艦種, (t, g) => new { Key = shipTypes[t], Value = g.ToArray() })
+					.ToArray();
 				WeaponTypeComboBox.DataSource = data.Weapons
 					.GroupBy(w => WeaponTypeToNumber.ContainsKey(w.種別) ? w.種別 : "その他", (t, g) => new { Key = t, Value = g.ToArray() })
 					.OrderBy(a => WeaponTypeToNumber[a.Key])
@@ -273,16 +278,14 @@ namespace KCS_GUI {
 
 		// 艦娘エディタタブ
 		private void AddKammusuButton_Click(object sender, EventArgs e) {
-			if(KammusuTypeComboBox.SelectedIndex == -1
-			|| KammusuNameComboBox.SelectedIndex == -1
-			|| FleetSelectComboBox.SelectedIndex == -1)
+			var kammusu = (CsvDataSet.ShipsRow)KammusuNameComboBox.SelectedItem;
+			if (kammusu == null || FleetSelectComboBox.SelectedIndex == -1)
 				return;
 			// 1艦隊には6隻まで
 			if(FormFleet.unit[FleetSelectComboBox.SelectedIndex].Count == MaxUnitSize)
 				return;
 			// 艦娘データを作成する
-			int index = KammusuTypeToIndexList[KammusuTypeComboBox.SelectedIndex][KammusuNameComboBox.SelectedIndex];
-			var id = data.Ships[index].艦船ID;
+			var id = kammusu.艦船ID;
 			var level = KammusuLevelTextBox.Text.ParseInt();
 			var luck = KammusuLuckTextBox.Text.ParseInt();
 			var cond = KammusuCondTextBox.Text.ParseInt();
@@ -367,14 +370,13 @@ namespace KCS_GUI {
 			}
 		}
 		private void ChangeKammusuButton_Click(object sender, EventArgs e) {
-			if(KammusuTypeComboBox.SelectedIndex == -1
-			|| KammusuNameComboBox.SelectedIndex == -1
+			var kammusu = (CsvDataSet.ShipsRow)KammusuNameComboBox.SelectedItem;
+			if(kammusu == null
 			|| FleetSelectComboBox.SelectedIndex == -1
 			|| KammusuSelectListBox.SelectedIndex == -1)
 				return;
 			// 艦娘データを作成する
-			int index = KammusuTypeToIndexList[KammusuTypeComboBox.SelectedIndex][KammusuNameComboBox.SelectedIndex];
-			var id = data.Ships[index].艦船ID;
+			var id = kammusu.艦船ID;
 			var level = KammusuLevelTextBox.Text.ParseInt();
 			var luck = KammusuLuckTextBox.Text.ParseInt();
 			var cond = KammusuCondTextBox.Text.ParseInt();
@@ -490,8 +492,7 @@ namespace KCS_GUI {
 			// 表示する艦娘を切り替える
 			int showKammusuType = kammusu.row.艦種 - 1;
 			KammusuTypeComboBox.SelectedIndex = showKammusuType;
-			KammusuTypeComboBox.Refresh();
-			KammusuNameComboBox.Text = kammusu.艦名;
+			KammusuNameComboBox.SelectedItem = kammusu;
 			RedrawKammusuNameList();
 			KammusuLevelTextBox.Text = kammusu.lv.ToString();
 			KammusuLuckTextBox.Text = kammusu.luck.ToString();
@@ -895,14 +896,8 @@ namespace KCS_GUI {
 		}
 		// 艦娘データをGUIに反映
 		private void RedrawKammusuNameList() {
-			KammusuNameComboBox.Items.Clear();
 			// 選択した種別に従って、リストを生成する
-			if(KammusuTypeComboBox.SelectedIndex < 0)
-				return;
-			foreach(int index in KammusuTypeToIndexList[KammusuTypeComboBox.SelectedIndex]) {
-				KammusuNameComboBox.Items.Add(data.Ships[index].艦名);
-			}
-			KammusuNameComboBox.Refresh();
+			KammusuNameComboBox.DataSource = KammusuTypeComboBox.SelectedValue;
 		}
 		private void RedrawMapKammusuNameList() {
 			MapKammusuNameComboBox.Items.Clear();

--- a/KCS_GUI/Form1.cs
+++ b/KCS_GUI/Form1.cs
@@ -671,8 +671,6 @@ namespace KCS_GUI {
 			var selectFleet = selectPosition.pattern[MapPatternListBox.SelectedIndex];
 			int selectPositionCount = selectPosition.pattern.Count;
 			selectFleet.fleets.Add(setKammusu);
-			MapKammusuListBox.Items.Add(setKammusu.艦名);
-			MapKammusuListBox.Refresh();
 			MapPatternListBox.Items[MapPatternListBox.SelectedIndex] = selectPositionCount.ToString() + " : " + selectFleet.fleets.Count.ToString() + "隻";
 			RedrawMapAntiAirScore();
 			file_state_modified(FileState.modified);
@@ -689,8 +687,6 @@ namespace KCS_GUI {
 			// 艦娘データを追加
 			var selectFleet = FormMapData.position[MapPositionListBox.SelectedIndex].pattern[MapPatternListBox.SelectedIndex];
 			selectFleet.fleets[MapKammusuListBox.SelectedIndex] = setKammusu;
-			MapKammusuListBox.Items[MapKammusuListBox.SelectedIndex] = data.Ships.Single(s => s.艦船ID == setKammusu.id).艦名;
-			MapKammusuListBox.Refresh();
 			RedrawMapAntiAirScore();
 			file_state_modified(FileState.modified);
 		}
@@ -700,7 +696,6 @@ namespace KCS_GUI {
 			|| MapKammusuListBox.SelectedIndex == -1)
 				return;
 			FormMapData.position[MapPositionListBox.SelectedIndex].pattern[MapPatternListBox.SelectedIndex].fleets.RemoveAt(MapKammusuListBox.SelectedIndex);
-			MapKammusuListBox.Items.RemoveAt(MapKammusuListBox.SelectedIndex);
 			var selectPosition = FormMapData.position[MapPositionListBox.SelectedIndex];
 			var selectFleet = selectPosition.pattern[MapPatternListBox.SelectedIndex];
 			int selectPositionCount = selectPosition.pattern.Count;
@@ -735,24 +730,16 @@ namespace KCS_GUI {
 			MapPatternFormationComboBox.SelectedIndex = selectPosition.pattern[MapPatternListBox.SelectedIndex].form;
 			MapPatternFormationComboBox.Refresh();
 			// 選択したパターンについて、それに含まれる艦娘に関する情報
-			MapKammusuListBox.Items.Clear();
-			var selectFleet = selectPosition.pattern[MapPatternListBox.SelectedIndex].fleets;
-			foreach(var kammusu in selectFleet) {
-				MapKammusuListBox.Items.Add(data.Ships.Single(s => s.艦船ID == kammusu.id).艦名);
-			}
-			MapKammusuListBox.Refresh();
+			MapKammusuListBox.DataSource = selectPosition.pattern[MapPatternListBox.SelectedIndex].fleets;
 			RedrawMapAntiAirScore();
 		}
 		private void MapKammusuListBox_SelectedIndexChanged(object sender, EventArgs e) {
-			if(MapPositionListBox.SelectedIndex == -1
-			|| MapPatternListBox.SelectedIndex == -1
-			|| MapKammusuListBox.SelectedIndex == -1)
+			var kammusu = (Kammusu)MapKammusuListBox.SelectedItem;
+			if (kammusu == null)
 				return;
 			// 表示する艦娘を切り替える
-			Kammusu kammusu = FormMapData.position[MapPositionListBox.SelectedIndex].pattern[MapPatternListBox.SelectedIndex].fleets[MapKammusuListBox.SelectedIndex];
-			var showKammusu = data.Ships.Single(s => s.艦船ID == kammusu.id);
-			MapKammusuTypeComboBox.SelectedIndex = showKammusu.艦種 - 1;
-			MapKammusuNameComboBox.Text = showKammusu.艦名;
+			MapKammusuTypeComboBox.SelectedIndex = kammusu.row.艦種 - 1;
+			MapKammusuNameComboBox.SelectedItem = kammusu.row;
 			RedrawMapKammusuNameList();
 		}
 

--- a/KCS_GUI/Form1.cs
+++ b/KCS_GUI/Form1.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
 using System.ComponentModel;
+using static KCS_GUI.CsvDataSet;
 
 namespace KCS_GUI {
 	public partial class MainForm : Form {
@@ -20,18 +21,12 @@ namespace KCS_GUI {
 		const int MaxFleetSize = 2;
 		//艦隊における艦船数の最大
 		const int MaxUnitSize = 6;
-		//種別→種別番号変換
-		static Dictionary<string, int> WeaponTypeToNumber;
 		//制空計算用(艦戦ボーナスと艦爆ボーナス)
 		static List<double> bonusPF = new List<double> { 0.0, 0.0, 2.0, 5.0, 9.0, 14.0, 14.0, 22.0 };
 		static List<double> bonusWB = new List<double> { 0.0, 0.0, 1.0, 1.0, 1.0, 3.0, 3.0, 6.0 };
 
-		// 装備・艦娘データ
-		static CsvDataSet data = new CsvDataSet();
 		//種別番号→インデックスのリスト変換
 		Dictionary<int, List<int>> WeaponTypeToIndexList;
-		//熟練度が存在する装備の種別番号一覧
-		static List<int> RfWeaponTypeList;
 		//艦種番号→インデックスのリスト変換
 		Dictionary<int, List<int>> KammusuTypeToIndexList;
 		// 画面表示用データ
@@ -48,61 +43,9 @@ namespace KCS_GUI {
 		private System.Windows.Forms.ErrorProvider error_provider_luck;
 		private System.Windows.Forms.ErrorProvider error_provider_cond;
 		/* コンストラクタ */
-		static MainForm() {
-			using(var adapter = new CsvDataSetTableAdapters.ShipsTableAdapter())
-				adapter.Fill(data.Ships);
-			using(var adapter = new CsvDataSetTableAdapters.WeaponsTableAdapter())
-				adapter.Fill(data.Weapons);
-		}
 		public MainForm() {
 			InitializeComponent();
 			try {
-				WeaponTypeToNumber = new Dictionary<string, int>() {
-					{"主砲",0},
-					{"対艦強化弾",1},
-					{"副砲",2},
-					{"魚雷",3},
-					{"特殊潜航艇",4},
-					{"艦上戦闘機",5},
-					{"艦上爆撃機",6},
-					{"艦上爆撃機(爆戦)",7},
-					{"水上爆撃機",8},
-					{"艦上攻撃機",9},
-					{"艦上偵察機",10},
-					{"艦上偵察機(彩雲)",11},
-					{"大型飛行艇",12},
-					{"水上偵察機",13},
-					{"水上偵察機(夜偵)",14},
-					{"対潜哨戒機",15},
-					{"オートジャイロ",16},
-					{"小型電探",17},
-					{"大型電探",18},
-					{"対空機銃",19},
-					{"対空強化弾",20},
-					{"高射装置",21},
-					{"爆雷",22},
-					{"ソナー",23},
-					{"応急修理要員",24},
-					{"探照灯",25},
-					{"照明弾",26},
-					{"艦隊司令部施設",27},
-					{"水上艦要員",28},
-					{"戦闘糧食",29},
-					{"洋上補給",30},
-					{"水上戦闘機",31},
-					{"その他",32}
-				};
-				RfWeaponTypeList = new List<int> {
-					WeaponTypeToNumber["艦上戦闘機"],
-					WeaponTypeToNumber["艦上爆撃機"],
-					WeaponTypeToNumber["艦上爆撃機(爆戦)"],
-					WeaponTypeToNumber["水上爆撃機"],
-					WeaponTypeToNumber["艦上攻撃機"],
-					WeaponTypeToNumber["艦上偵察機"],
-					WeaponTypeToNumber["艦上偵察機(彩雲)"],
-					WeaponTypeToNumber["大型飛行艇"],
-					WeaponTypeToNumber["水上戦闘機"]
-				};
 				ReadWeaponData();
 				ReadKammusuData();
 				RedrawWeaponNameList();
@@ -994,7 +937,7 @@ namespace KCS_GUI {
 			}
 			WeaponNameComboBox.Refresh();
 			// 改修度および熟練度の選択を切り替える
-			if(RfWeaponTypeList.IndexOf(WeaponTypeComboBox.SelectedIndex) != -1) {
+			if(RfWeaponTypeList.Contains(WeaponTypeComboBox.SelectedIndex)) {
 				// 熟練度
 				WeaponLevelComboBox.Enabled = false;
 				WeaponRfComboBox.Enabled = true;
@@ -1125,7 +1068,7 @@ namespace KCS_GUI {
 						if(WeaponTypeToNumber.ContainsKey(data.Weapons.Single(w => w.装備ID == setWeapon.id).種別)) {
 							setWeaponType = WeaponTypeToNumber[data.Weapons.Single(w => w.装備ID == setWeapon.id).種別];
 						}
-						if(RfWeaponTypeList.IndexOf(setWeaponType) != -1) {
+						if(RfWeaponTypeList.Contains(setWeaponType)) {
 							setWeapon.level = 0;
 							setWeapon.rf = limit(int.Parse((string)jsonWeapon["rf"]), 0, 7);
 							if(jsonWeapon["rf_detail"] == null) {
@@ -1303,7 +1246,7 @@ namespace KCS_GUI {
 							if(WeaponTypeToNumber.ContainsKey(data.Weapons.Single(w => w.装備ID == unit[fi][si].weapon[wi].id).種別)) {
 								setWeaponType = WeaponTypeToNumber[data.Weapons.Single(w => w.装備ID == unit[fi][si].weapon[wi].id).種別];
 							}
-							if(RfWeaponTypeList.IndexOf(setWeaponType) != -1) {
+							if(RfWeaponTypeList.Contains(setWeaponType)) {
 								setWeapon["rf"] = unit[fi][si].weapon[wi].rf;
 								setWeapon["rf_detail"] = unit[fi][si].weapon[wi].detailRf;
 							} else {

--- a/KCS_GUI/Form1.cs
+++ b/KCS_GUI/Form1.cs
@@ -425,60 +425,28 @@ namespace KCS_GUI {
 			var setWeapon = new Weapon(id, level, rf, detailRf);
 			// 作成した装備データを追加する
 			selectedKammusu.items.Add(setWeapon);
-			WeaponSelectListBox.Items.Add(setWeapon.装備名);
-			WeaponSelectListBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 			file_state_modified(FileState.modified);
 		}
 		private void WeaponLevelComboBox_Leave(object sender, EventArgs e) {
-			if (//Range Check
-				IsVaidIndex(this.FleetSelectComboBox.SelectedIndex, this.FormFleet.unit.Count)
-				&& IsVaidIndex(this.KammusuSelectListBox.SelectedIndex, this.FormFleet.unit[FleetSelectComboBox.SelectedIndex].Count)
-				&& IsVaidIndex(
-					this.WeaponSelectListBox.SelectedIndex,
-					this.FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex].items.Count
-				)
-			) {
-				this
-					.FormFleet
-					.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex]
-					.items[WeaponSelectListBox.SelectedIndex]
-					.level = WeaponLevelComboBox.SelectedIndex;
+			var weapon = (Weapon)WeaponSelectListBox.SelectedItem;
+			if (weapon != null) {
+				weapon.level = WeaponLevelComboBox.SelectedIndex;
 				file_state_modified(FileState.modified);
 			}
 		}
 		private void WeaponRfComboBox_Leave(object sender, EventArgs e) {
-			if(//Range Check
-				IsVaidIndex(this.FleetSelectComboBox.SelectedIndex, this.FormFleet.unit.Count)
-				&& IsVaidIndex(this.KammusuSelectListBox.SelectedIndex, this.FormFleet.unit[FleetSelectComboBox.SelectedIndex].Count)
-				&& IsVaidIndex(
-					this.WeaponSelectListBox.SelectedIndex,
-					this.FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex].items.Count
-				)
-			) {
-				this
-					.FormFleet
-					.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex]
-					.items[WeaponSelectListBox.SelectedIndex]
-					.rf = WeaponRfComboBox.SelectedIndex;
+			var weapon = (Weapon)WeaponSelectListBox.SelectedItem;
+			if (weapon != null) {
+				weapon.rf = WeaponRfComboBox.SelectedIndex;
 				file_state_modified(FileState.modified);
 			}
 		}
 		private void WeaponDetailRfComboBox_Leave(object sender, EventArgs e) {
-			if(//Range Check
-				IsVaidIndex(this.FleetSelectComboBox.SelectedIndex, this.FormFleet.unit.Count)
-				&& IsVaidIndex(this.KammusuSelectListBox.SelectedIndex, this.FormFleet.unit[FleetSelectComboBox.SelectedIndex].Count)
-				&& IsVaidIndex(
-					this.WeaponSelectListBox.SelectedIndex,
-					this.FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex].items.Count
-				)
-			) {
-				this
-					.FormFleet
-					.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex]
-					.items[WeaponSelectListBox.SelectedIndex]
-					.rf_detail = WeaponDetailRfComboBox.SelectedIndex;
+			var weapon = (Weapon)WeaponSelectListBox.SelectedItem;
+			if (weapon != null) {
+				weapon.rf_detail = WeaponDetailRfComboBox.SelectedIndex;
 				file_state_modified(FileState.modified);
 			}
 		}
@@ -499,8 +467,6 @@ namespace KCS_GUI {
 			var setWeapon = new Weapon(id, level, rf, detailRf);
 			// 作成した装備データで上書きする
 			selectedKammusu.items[WeaponSelectListBox.SelectedIndex] = setWeapon;
-			WeaponSelectListBox.Items[WeaponSelectListBox.SelectedIndex] = setWeapon.装備名;
-			WeaponSelectListBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 			file_state_modified(FileState.modified);
@@ -512,8 +478,6 @@ namespace KCS_GUI {
 				return;
 			// FormFleetから装備データを削除する
 			FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex].items.RemoveAt(WeaponSelectListBox.SelectedIndex);
-			WeaponSelectListBox.Items.RemoveAt(WeaponSelectListBox.SelectedIndex);
-			WeaponSelectListBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 			file_state_modified(FileState.modified);
@@ -558,11 +522,7 @@ namespace KCS_GUI {
 			KammusuLuckTextBox.Text = kammusu.luck.ToString();
 			KammusuCondTextBox.Text = kammusu.cond.ToString();
 			// 装備一覧を更新する
-			WeaponSelectListBox.Items.Clear();
-			foreach(var weapon in kammusu.items) {
-				WeaponSelectListBox.Items.Add(data.Weapons.Single(w => w.装備ID == weapon.id).装備名);
-			}
-			WeaponSelectListBox.Refresh();
+			WeaponSelectListBox.DataSource = kammusu.items;
 		}
 		private void KammusuTypeComboBox_SelectedIndexChanged(object sender, EventArgs e) {
 			RedrawKammusuNameList();
@@ -571,21 +531,16 @@ namespace KCS_GUI {
 			RedrawWeaponNameList();
 		}
 		private void WeaponSelectListBox_SelectedIndexChanged(object sender, EventArgs e) {
-			if(FleetSelectComboBox.SelectedIndex == -1
-			|| KammusuSelectListBox.SelectedIndex == -1
-			|| WeaponSelectListBox.SelectedIndex == -1)
+			var weapon = (Weapon)WeaponSelectListBox.SelectedItem;
+			if (weapon == null)
 				return;
 			// 表示する装備を切り替える
-			Kammusu kammusu = FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex];
-			Weapon weapon = kammusu.items[WeaponSelectListBox.SelectedIndex];
-			var showWeapon = data.Weapons.Single(w => w.装備ID == weapon.id);
-			int showWeaponType = WeaponTypeToNumber["その他"];
-			if(WeaponTypeToNumber.ContainsKey(showWeapon.種別)) {
-				showWeaponType = WeaponTypeToNumber[showWeapon.種別];
-			}
+			int showWeaponType;
+			if (!WeaponTypeToNumber.TryGetValue(weapon.row.種別, out showWeaponType))
+				showWeaponType = WeaponTypeToNumber["その他"];
 			WeaponTypeComboBox.SelectedIndex = showWeaponType;
 			WeaponTypeComboBox.Refresh();
-			WeaponNameComboBox.Text = showWeapon.装備名;
+			WeaponNameComboBox.Text = weapon.装備名;
 			RedrawWeaponNameList();
 			WeaponLevelComboBox.SelectedIndex = weapon.level;
 			WeaponLevelComboBox.Refresh();

--- a/KCS_GUI/Form1.cs
+++ b/KCS_GUI/Form1.cs
@@ -288,8 +288,6 @@ namespace KCS_GUI {
 			var setKammusu = new Kammusu(id, level, luck, cond);
 			// 作成した艦娘データを追加する
 			FormFleet.unit[FleetSelectComboBox.SelectedIndex].Add(setKammusu);
-			KammusuSelectListBox.Items.Add(setKammusu.艦名);
-			KammusuSelectListBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 			file_state_modified(FileState.modified);
@@ -317,11 +315,9 @@ namespace KCS_GUI {
 			}
 		}
 		private void KammusuLevelTextBox_Leave(object sender, EventArgs e) {
-			if(//Range Check
-				IsVaidIndex(this.FleetSelectComboBox.SelectedIndex, this.FormFleet.unit.Count)
-				&& IsVaidIndex(this.KammusuSelectListBox.SelectedIndex, this.FormFleet.unit[FleetSelectComboBox.SelectedIndex].Count)
-			)
-				FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex].lv = int.Parse(KammusuLevelTextBox.Text);
+			var kammusu = (Kammusu)KammusuSelectListBox.SelectedItem;
+			if (kammusu != null)
+				kammusu.lv = int.Parse(KammusuLevelTextBox.Text);
 		}
 		private void KammusuLuckTextBox_Validating(object sender, CancelEventArgs e) {
 			try {
@@ -340,11 +336,9 @@ namespace KCS_GUI {
 			}
 		}
 		private void KammusuLuckTextBox_Leave(object sender, EventArgs e) {
-			if (//Range Check
-				IsVaidIndex(this.FleetSelectComboBox.SelectedIndex, this.FormFleet.unit.Count)
-				&& IsVaidIndex(this.KammusuSelectListBox.SelectedIndex, this.FormFleet.unit[FleetSelectComboBox.SelectedIndex].Count)
-			) {
-				FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex].luck = KammusuLuckTextBox.Text.ParseInt();
+			var kammusu = (Kammusu)KammusuSelectListBox.SelectedItem;
+			if (kammusu != null) {
+				kammusu.luck = KammusuLuckTextBox.Text.ParseInt();
 				file_state_modified(FileState.modified);
 			}
 		}
@@ -365,11 +359,9 @@ namespace KCS_GUI {
 			}
 		}
 		private void KammusuCondTextBox_Leave(object sender, EventArgs e) {
-			if (//Range Check
-				IsVaidIndex(this.FleetSelectComboBox.SelectedIndex, this.FormFleet.unit.Count)
-				&& IsVaidIndex(this.KammusuSelectListBox.SelectedIndex, this.FormFleet.unit[FleetSelectComboBox.SelectedIndex].Count)
-			) {
-				FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex].cond = KammusuCondTextBox.Text.ParseInt();
+			var kammusu = (Kammusu)KammusuSelectListBox.SelectedItem;
+			if (kammusu != null) {
+				kammusu.cond = KammusuCondTextBox.Text.ParseInt();
 				file_state_modified(FileState.modified);
 			}
 		}
@@ -388,8 +380,6 @@ namespace KCS_GUI {
 			var setKammusu = new Kammusu(id, level, luck, cond);
 			// 作成した艦娘データで上書きする
 			FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex] = setKammusu;
-			KammusuSelectListBox.Items[KammusuSelectListBox.SelectedIndex] = setKammusu.艦名;
-			KammusuSelectListBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 			file_state_modified(FileState.modified);
@@ -400,21 +390,18 @@ namespace KCS_GUI {
 				return;
 			// FormFleetから艦娘データを削除する
 			FormFleet.unit[FleetSelectComboBox.SelectedIndex].RemoveAt(KammusuSelectListBox.SelectedIndex);
-			KammusuSelectListBox.Items.RemoveAt(KammusuSelectListBox.SelectedIndex);
-			KammusuSelectListBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 			file_state_modified(FileState.modified);
 		}
 		private void AddWeaponButton_Click(object sender, EventArgs e) {
-			if(FleetSelectComboBox.SelectedIndex == -1
-			|| KammusuSelectListBox.SelectedIndex == -1
+			var kammusu = (Kammusu)KammusuSelectListBox.SelectedItem;
+			if(kammusu == null
 			|| WeaponTypeComboBox.SelectedIndex == -1
 			|| WeaponNameComboBox.SelectedIndex == -1)
 				return;
 			// 4つ以上の装備は持てない
-			Kammusu selectedKammusu = FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex];
-			if(selectedKammusu.items.Count == selectedKammusu.maxSlots)
+			if(kammusu.items.Count == kammusu.maxSlots)
 				return;
 			// 装備データを作成する
 			int index = WeaponTypeToIndexList[WeaponTypeComboBox.SelectedIndex][WeaponNameComboBox.SelectedIndex];
@@ -424,7 +411,7 @@ namespace KCS_GUI {
 			var detailRf = WeaponDetailRfComboBox.SelectedIndex;
 			var setWeapon = new Weapon(id, level, rf, detailRf);
 			// 作成した装備データを追加する
-			selectedKammusu.items.Add(setWeapon);
+			kammusu.items.Add(setWeapon);
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 			file_state_modified(FileState.modified);
@@ -451,13 +438,12 @@ namespace KCS_GUI {
 			}
 		}
 		private void ChangeWeaponButton_Click(object sender, EventArgs e) {
-			if(FleetSelectComboBox.SelectedIndex == -1
-			|| KammusuSelectListBox.SelectedIndex == -1
+			var kammusu = (Kammusu)KammusuSelectListBox.SelectedItem;
+			if(kammusu == null
 			|| WeaponTypeComboBox.SelectedIndex == -1
 			|| WeaponNameComboBox.SelectedIndex == -1
 			|| WeaponSelectListBox.SelectedIndex == -1)
 				return;
-			Kammusu selectedKammusu = FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex];
 			// 装備データを作成する
 			int index = WeaponTypeToIndexList[WeaponTypeComboBox.SelectedIndex][WeaponNameComboBox.SelectedIndex];
 			var id = data.Weapons[index].装備ID;
@@ -466,18 +452,17 @@ namespace KCS_GUI {
 			var detailRf = WeaponDetailRfComboBox.SelectedIndex.limit(0, 120);
 			var setWeapon = new Weapon(id, level, rf, detailRf);
 			// 作成した装備データで上書きする
-			selectedKammusu.items[WeaponSelectListBox.SelectedIndex] = setWeapon;
+			kammusu.items[WeaponSelectListBox.SelectedIndex] = setWeapon;
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 			file_state_modified(FileState.modified);
 		}
 		private void DeleteWeaponButton_Click(object sender, EventArgs e) {
-			if(FleetSelectComboBox.SelectedIndex == -1
-			|| KammusuSelectListBox.SelectedIndex == -1
-			|| WeaponSelectListBox.SelectedIndex == -1)
+			var kammusu = (Kammusu)KammusuSelectListBox.SelectedItem;
+			if (kammusu == null || WeaponSelectListBox.SelectedIndex == -1)
 				return;
 			// FormFleetから装備データを削除する
-			FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex].items.RemoveAt(WeaponSelectListBox.SelectedIndex);
+			kammusu.items.RemoveAt(WeaponSelectListBox.SelectedIndex);
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 			file_state_modified(FileState.modified);
@@ -499,24 +484,17 @@ namespace KCS_GUI {
 			if(FleetSelectComboBox.SelectedIndex == -1)
 				return;
 			// 表示する艦隊を切り換える
-			KammusuSelectListBox.ClearSelected();
-			KammusuSelectListBox.Items.Clear();
-			foreach(Kammusu kammusu in FormFleet.unit[FleetSelectComboBox.SelectedIndex]) {
-				KammusuSelectListBox.Items.Add(data.Ships.Single(s => s.艦船ID == kammusu.id).艦名);
-			}
-			KammusuSelectListBox.Refresh();
+			KammusuSelectListBox.DataSource = FormFleet.unit[FleetSelectComboBox.SelectedIndex];
 		}
 		private void KammusuSelectListBox_SelectedIndexChanged(object sender, EventArgs e) {
-			if(FleetSelectComboBox.SelectedIndex == -1
-			|| KammusuSelectListBox.SelectedIndex == -1)
+			var kammusu = (Kammusu)KammusuSelectListBox.SelectedItem;
+			if (kammusu == null)
 				return;
 			// 表示する艦娘を切り替える
-			Kammusu kammusu = FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex];
-			var showKammusu = data.Ships.Single(s => s.艦船ID == kammusu.id);
-			int showKammusuType = showKammusu.艦種 - 1;
+			int showKammusuType = kammusu.row.艦種 - 1;
 			KammusuTypeComboBox.SelectedIndex = showKammusuType;
 			KammusuTypeComboBox.Refresh();
-			KammusuNameComboBox.Text = showKammusu.艦名;
+			KammusuNameComboBox.Text = kammusu.艦名;
 			RedrawKammusuNameList();
 			KammusuLevelTextBox.Text = kammusu.lv.ToString();
 			KammusuLuckTextBox.Text = kammusu.luck.ToString();

--- a/KCS_GUI/Form1.cs
+++ b/KCS_GUI/Form1.cs
@@ -367,15 +367,15 @@ namespace KCS_GUI {
 			if(selectedKammusu.weapon.Count == selectedKammusu.maxSlots)
 				return;
 			// 装備データを作成する
-			var setWeapon = new Weapon();
 			int index = WeaponTypeToIndexList[WeaponTypeComboBox.SelectedIndex][WeaponNameComboBox.SelectedIndex];
-			setWeapon.id = data.Weapons[index].装備ID;
-			setWeapon.level = WeaponLevelComboBox.SelectedIndex.limit(0, 10);
-			setWeapon.rf = WeaponRfComboBox.SelectedIndex.limit(0, 7);
-			setWeapon.detailRf = WeaponDetailRfComboBox.SelectedIndex.limit(0, 120);
+			var id = data.Weapons[index].装備ID;
+			var level = WeaponLevelComboBox.SelectedIndex;
+			var rf = WeaponRfComboBox.SelectedIndex;
+			var detailRf = WeaponDetailRfComboBox.SelectedIndex;
+			var setWeapon = new Weapon(id, level, rf, detailRf);
 			// 作成した装備データを追加する
 			selectedKammusu.weapon.Add(setWeapon);
-			WeaponSelectListBox.Items.Add(data.Weapons.Single(w => w.装備ID == setWeapon.id).装備名);
+			WeaponSelectListBox.Items.Add(setWeapon.装備名);
 			WeaponSelectListBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
@@ -393,7 +393,7 @@ namespace KCS_GUI {
 					.FormFleet
 					.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex]
 					.weapon[WeaponSelectListBox.SelectedIndex]
-					.level = limit(WeaponLevelComboBox.SelectedIndex, 0, 10);
+					.level = WeaponLevelComboBox.SelectedIndex;
 		}
 		private void WeaponRfComboBox_Leave(object sender, EventArgs e) {
 			if(//Range Check
@@ -408,7 +408,7 @@ namespace KCS_GUI {
 					.FormFleet
 					.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex]
 					.weapon[WeaponSelectListBox.SelectedIndex]
-					.set_rf(WeaponRfComboBox.SelectedIndex);
+					.rf = WeaponRfComboBox.SelectedIndex;
 			}
 		}
 		private void WeaponDetailRfComboBox_Leave(object sender, EventArgs e) {
@@ -424,7 +424,7 @@ namespace KCS_GUI {
 					.FormFleet
 					.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex]
 					.weapon[WeaponSelectListBox.SelectedIndex]
-					.set_detailRf(WeaponDetailRfComboBox.SelectedIndex);
+					.rf_detail = WeaponDetailRfComboBox.SelectedIndex;
 			}
 		}
 		private void ChangeWeaponButton_Click(object sender, EventArgs e) {
@@ -436,15 +436,15 @@ namespace KCS_GUI {
 				return;
 			Kammusu selectedKammusu = FormFleet.unit[FleetSelectComboBox.SelectedIndex][KammusuSelectListBox.SelectedIndex];
 			// 装備データを作成する
-			var setWeapon = new Weapon();
 			int index = WeaponTypeToIndexList[WeaponTypeComboBox.SelectedIndex][WeaponNameComboBox.SelectedIndex];
-			setWeapon.id = data.Weapons[index].装備ID;
-			setWeapon.level = WeaponLevelComboBox.SelectedIndex.limit(0, 10);
-			setWeapon.rf = WeaponRfComboBox.SelectedIndex.limit(0, 7);
-			setWeapon.detailRf = WeaponDetailRfComboBox.SelectedIndex.limit(0, 120);
+			var id = data.Weapons[index].装備ID;
+			var level = WeaponLevelComboBox.SelectedIndex.limit(0, 10);
+			var rf = WeaponRfComboBox.SelectedIndex.limit(0, 7);
+			var detailRf = WeaponDetailRfComboBox.SelectedIndex.limit(0, 120);
+			var setWeapon = new Weapon(id, level, rf, detailRf);
 			// 作成した装備データで上書きする
 			selectedKammusu.weapon[WeaponSelectListBox.SelectedIndex] = setWeapon;
-			WeaponSelectListBox.Items[WeaponSelectListBox.SelectedIndex] = data.Weapons.Single(w => w.装備ID == setWeapon.id).装備名;
+			WeaponSelectListBox.Items[WeaponSelectListBox.SelectedIndex] = setWeapon.装備名;
 			WeaponSelectListBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
@@ -532,19 +532,19 @@ namespace KCS_GUI {
 			WeaponLevelComboBox.Refresh();
 			WeaponRfComboBox.SelectedIndex = weapon.rf;
 			WeaponRfComboBox.Refresh();
-			WeaponDetailRfComboBox.SelectedIndex = weapon.detailRf;
+			WeaponDetailRfComboBox.SelectedIndex = weapon.rf_detail;
 			WeaponDetailRfComboBox.Refresh();
 		}
 		private void WeaponRfComboBox_SelectedIndexChanged(object sender, EventArgs e) {
 			// 外部熟練度を弄った場合、内部熟練度を自動補正する
-			WeaponDetailRfComboBox.SelectedIndex = rfRoughToDetail(WeaponRfComboBox.SelectedIndex);
+			WeaponDetailRfComboBox.SelectedIndex = Weapon.ToDetail(WeaponRfComboBox.SelectedIndex);
 			WeaponDetailRfComboBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
 		}
 		private void WeaponDetailRfComboBox_SelectedIndexChanged(object sender, EventArgs e) {
 			// 内部熟練度を弄った場合、外部熟練度を自動補正する
-			WeaponRfComboBox.SelectedIndex = rfDetailToRough(WeaponDetailRfComboBox.SelectedIndex);
+			WeaponRfComboBox.SelectedIndex = Weapon.FromDetail(WeaponDetailRfComboBox.SelectedIndex);
 			WeaponRfComboBox.Refresh();
 			RedrawAntiAirScore();
 			RedrawSearchPower();
@@ -686,12 +686,7 @@ namespace KCS_GUI {
 				var weaponIdToInt = weaponID.ParseInt();
 				if(weaponIdToInt <= 0)
 					break;
-				var setWeapon = new Weapon();
-				setWeapon.id = weaponIdToInt;
-				setWeapon.level = 0;
-				setWeapon.rf = 0;
-				setWeapon.detailRf = 0;
-				setKammusu.weapon.Add(setWeapon);
+				setKammusu.weapon.Add(new Weapon(weaponIdToInt));
 			}
 			// 艦娘データを追加
 			var selectPosition = FormMapData.position[MapPositionListBox.SelectedIndex];
@@ -721,12 +716,7 @@ namespace KCS_GUI {
 				var weaponIdToInt = weaponID.ParseInt();
 				if(weaponIdToInt <= 0)
 					break;
-				var setWeapon = new Weapon();
-				setWeapon.id = weaponIdToInt;
-				setWeapon.level = 0;
-				setWeapon.rf = 0;
-				setWeapon.detailRf = 0;
-				setKammusu.weapon.Add(setWeapon);
+				setKammusu.weapon.Add(new Weapon(weaponIdToInt));
 			}
 			// 艦娘データを追加
 			var selectFleet = FormMapData.position[MapPositionListBox.SelectedIndex].fleet[MapPatternListBox.SelectedIndex];
@@ -974,32 +964,6 @@ namespace KCS_GUI {
 		static public int limit(int n, int min_n, int max_n) {
 			return (n < min_n) ? min_n : (max_n < n) ? max_n : n;
 		}
-		// 外部熟練度を内部熟練度に変換する
-		static public int rfRoughToDetail(int rf) {
-			int[] roughToDetailList = new int[8] { 0, 10, 25, 40, 55, 70, 85, 100 };
-			return roughToDetailList[rf];
-		}
-		// 内部熟練度を外部熟練度に変換する
-		static public int rfDetailToRough(int detailRf) {
-			int roughRf;
-			if(detailRf < 10)
-				roughRf = 0;
-			else if(detailRf < 25)
-				roughRf = 1;
-			else if(detailRf < 40)
-				roughRf = 2;
-			else if(detailRf < 55)
-				roughRf = 3;
-			else if(detailRf < 70)
-				roughRf = 4;
-			else if(detailRf < 85)
-				roughRf = 5;
-			else if(detailRf < 100)
-				roughRf = 6;
-			else
-				roughRf = 7;
-			return roughRf;
-		}
 		private Tuple<Fleet, bool> ReadJsonFile(string jsonFileName) {
 			Fleet setFleet = new Fleet();
 			// テキストを読み込んでJSONにパースする
@@ -1052,37 +1016,15 @@ namespace KCS_GUI {
 					// 装備を読み込む
 					for(int wi = 1; wi <= slotSize; ++wi) {
 						// JSONデータとしての判定
-						if(jsonItems["i" + wi.ToString()] == null)
+						var jsonWeapon = jsonItems["i" + wi];
+						if (jsonWeapon == null)
 							break;
-						var jsonWeapon = (JObject)jsonItems["i" + wi.ToString()];
-						if(jsonWeapon["id"] == null
-						|| jsonWeapon["rf"] == null)
-							return new Tuple<Fleet, bool>(setFleet, false);
-						var setWeapon = new Weapon();
-						// IDがデータベースに存在するか判定
-						setWeapon.id = limit(int.Parse((string)jsonWeapon["id"]), 1, 999);
-						if(!data.Weapons.Any(w => w.装備ID == setWeapon.id))
-							return new Tuple<Fleet, bool>(setFleet, false);
-						// 種別を判定することで、"rf"が装備改修度か艦載機熟練度かを判別する
-						int setWeaponType = WeaponTypeToNumber["その他"];
-						if(WeaponTypeToNumber.ContainsKey(data.Weapons.Single(w => w.装備ID == setWeapon.id).種別)) {
-							setWeaponType = WeaponTypeToNumber[data.Weapons.Single(w => w.装備ID == setWeapon.id).種別];
+						try {
+							setKammusu.weapon.Add(jsonWeapon.ToObject<Weapon>());
 						}
-						if(RfWeaponTypeList.Contains(setWeaponType)) {
-							setWeapon.level = 0;
-							setWeapon.rf = limit(int.Parse((string)jsonWeapon["rf"]), 0, 7);
-							if(jsonWeapon["rf_detail"] == null) {
-								setWeapon.detailRf = rfRoughToDetail(setWeapon.rf);
-							} else {
-								setWeapon.detailRf = limit(int.Parse((string)jsonWeapon["rf_detail"]), 0, 120);
-								setWeapon.rf = rfDetailToRough(setWeapon.detailRf);
-							}
-						} else {
-							setWeapon.level = limit(int.Parse((string)jsonWeapon["rf"]), 0, 10);
-							setWeapon.rf = 0;
-							setWeapon.detailRf = 0;
+						catch {
+							return new Tuple<Fleet, bool>(setFleet, false);
 						}
-						setKammusu.weapon.Add(setWeapon);
 					}
 					setFleet.unit[fi - 1].Add(setKammusu);
 				}
@@ -1116,12 +1058,7 @@ namespace KCS_GUI {
 							var weaponIdToInt = weaponID.ParseInt();
 							if(weaponIdToInt <= 0)
 								break;
-							var setWeapon = new Weapon();
-							setWeapon.id = weaponIdToInt;
-							setWeapon.level = 0;
-							setWeapon.rf = 0;
-							setWeapon.detailRf = 0;
-							kammusu.weapon.Add(setWeapon);
+							kammusu.weapon.Add(new Weapon(weaponIdToInt));
 						}
 						kammusu.maxSlots = kammusu.weapon.Count();
 						fleet.unit[0].Add(kammusu);
@@ -1153,28 +1090,6 @@ namespace KCS_GUI {
 			MapPatternAllAntiAirTextBox.Text = antiAirScore.ToString();
 		}
 		/* サブクラス */
-		// 装備
-		private class Weapon {
-			// 装備ID
-			public int id;
-			// 装備改修度
-			public int level;
-			// 外部熟練度
-			public int rf;
-			// 内部熟練度
-			public int detailRf;
-
-			public void set_rf(int i_rf) {
-				this.rf = limit(i_rf, 0, 7);
-				this.detailRf = MainForm.rfRoughToDetail(this.rf);
-			}
-
-			public void set_detailRf(int i_detailRf) {
-				this.detailRf = limit(i_detailRf, 0, 120);
-				this.rf = MainForm.rfDetailToRough(this.detailRf);
-			}
-
-		}
 		// 艦娘
 		private class Kammusu {
 			// 艦船ID
@@ -1239,20 +1154,7 @@ namespace KCS_GUI {
 						JObject setItems = new JObject();
 						for(int wi = 0; wi < unit[fi][si].weapon.Count; ++wi) {
 							// 装備
-							JObject setWeapon = new JObject();
-							setWeapon["id"] = unit[fi][si].weapon[wi].id;
-							//種別を判定することで、装備改修度か艦載機熟練度かを判別する
-							int setWeaponType = WeaponTypeToNumber["その他"];
-							if(WeaponTypeToNumber.ContainsKey(data.Weapons.Single(w => w.装備ID == unit[fi][si].weapon[wi].id).種別)) {
-								setWeaponType = WeaponTypeToNumber[data.Weapons.Single(w => w.装備ID == unit[fi][si].weapon[wi].id).種別];
-							}
-							if(RfWeaponTypeList.Contains(setWeaponType)) {
-								setWeapon["rf"] = unit[fi][si].weapon[wi].rf;
-								setWeapon["rf_detail"] = unit[fi][si].weapon[wi].detailRf;
-							} else {
-								setWeapon["rf"] = unit[fi][si].weapon[wi].level;
-							}
-							setItems["i" + (wi + 1).ToString()] = setWeapon;
+							setItems[$"i{wi + 1}"] = new JValue(unit[fi][si].weapon[wi]);
 						}
 						setKammusu["items"] = setItems;
 						setFleet["s" + (si + 1).ToString()] = setKammusu;
@@ -1282,7 +1184,7 @@ namespace KCS_GUI {
 						// 対空値・搭載数・内部熟練度で決まる制空値を代入する
 						var antiAir = weaponInfo.対空;
 						var slot = slots[wi].ParseInt();
-						double antiAirScoreWeapon = antiAir * Math.Sqrt(slot) + Math.Sqrt(0.1 * weapon.detailRf);
+						double antiAirScoreWeapon = antiAir * Math.Sqrt(slot) + Math.Sqrt(0.1 * weapon.rf_detail);
 						// 一部の種別には特別な補正を掛ける
 						if(type == "艦上戦闘機") {
 							antiAirScoreWeapon += bonusPF[weapon.rf];

--- a/KCS_GUI/JsonModels.cs
+++ b/KCS_GUI/JsonModels.cs
@@ -143,17 +143,14 @@ namespace KCS_GUI {
 		public int maxSlots { get { return row.スロット数; } }
 
 		[JsonConstructor]
-		public Kammusu(int id, int lv, int luck, int cond = 49) {
+		public Kammusu(int id, int lv = 1, int luck = -1, int cond = 49, [JsonConverter(typeof(ListJsonConverter<Weapon>), "i")] IList<Weapon> items = null) {
 			row = data.Ships.SingleOrDefault(s => s.艦船ID == id);
 			if (row == null)
 				throw new ArgumentOutOfRangeException("id");
 			this.lv = lv;
 			this.luck = luck;
 			this.cond = cond;
-		}
-
-		public Kammusu(int id) : this(id, 1, -1) {
-			items = new BindingList<Weapon>(
+			this.items = items ?? new BindingList<Weapon>(
 				row.初期装備
 					.Split('/')
 					.Select(Int32.Parse)

--- a/KCS_GUI/JsonModels.cs
+++ b/KCS_GUI/JsonModels.cs
@@ -1,2 +1,99 @@
-﻿namespace KCS_GUI {
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using Newtonsoft.Json;
+using static KCS_GUI.CsvDataSet;
+
+namespace KCS_GUI {
+	// 装備
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	class Weapon {
+		public readonly CsvDataSet.WeaponsRow row;
+		readonly bool isAir;
+		int level_;
+		int rf_;
+		int rf_detail_;
+
+		// 装備ID
+		[JsonProperty]
+		public int id { get { return row.装備ID; } }
+
+		public string 装備名 { get { return row.装備名; } }
+
+		// rfのSerialzeに使用する
+		[JsonProperty("rf"), EditorBrowsable(EditorBrowsableState.Never)]
+		public int rf_or_level {
+			get { return isAir ? rf : level; }
+		}
+
+		// 装備改修度
+		public int level {
+			get { return level_; }
+			set { level_ = value.limit(0, 10); }
+		}
+
+		// 外部熟練度
+		public int rf {
+			get { return rf_; }
+			set {
+				rf_ = value.limit(0, 7);
+				rf_detail_ = ToDetail(rf_);
+			}
+		}
+
+		// 内部熟練度
+		[JsonProperty]
+		public int rf_detail {
+			get { return rf_detail_; }
+			set {
+				rf_detail_ = value.limit(0, 120);
+				rf_ = FromDetail(rf_detail_);
+			}
+		}
+
+		public Weapon(int id) {
+			// IDがデータベースに存在するか判定
+			row = data.Weapons.SingleOrDefault(w => w.装備ID == id);
+			if (row == null)
+				throw new ArgumentOutOfRangeException("id");
+			// 種別を判定することで、"rf"が装備改修度か艦載機熟練度かを判別する
+			int setWeaponType;
+			if (!WeaponTypeToNumber.TryGetValue(row.種別, out setWeaponType))
+				setWeaponType = WeaponTypeToNumber["その他"];
+			isAir = RfWeaponTypeList.Contains(setWeaponType);
+		}
+
+		public Weapon(int id, int level, int rf, int rf_detail) : this(id) {
+			this.level = level;
+			this.rf_ = rf.limit(0, 7);
+			this.rf_detail_ = rf_detail.limit(0, 120);
+		}
+
+		[JsonConstructor]
+		public Weapon(int id, int rf, int? rf_detail) : this(id) {
+			if (isAir) {
+				if (rf_detail == null)
+					this.rf = rf;
+				else
+					this.rf_detail = rf_detail.Value;
+			} else
+				this.level = rf;
+		}
+
+		// JSONにrf_detailを書き出すか、Serializerが使用する
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool ShouldSerializerf_detail() {
+			return isAir && ToDetail(rf) != rf_detail;
+		}
+
+		// 外部熟練度を内部熟練度に変換する
+		public static int ToDetail(int rf) {
+			return (rf * 15 - 5).limit(0, 120);
+		}
+
+		// 内部熟練度を外部熟練度に変換する
+		public static int FromDetail(int rf_detail) {
+			return ((rf_detail + 5) / 15).limit(0, 7);
+		}
+	}
 }

--- a/KCS_GUI/JsonModels.cs
+++ b/KCS_GUI/JsonModels.cs
@@ -222,6 +222,39 @@ namespace KCS_GUI {
 			File.WriteAllText(path, JsonConvert.SerializeObject(this));
 		}
 	}
+	class Pattern {
+		public int form;
+		[JsonProperty(ItemConverterType = typeof(KammusuIdJsonConverter))]
+		public IList<Kammusu> fleets = new List<Kammusu>();
+	}
+	// マスデータ
+	class Position {
+		// マスにおける戦闘モード
+		public int mode;
+		// マスの名称
+		public string name;
+		// 各パターン
+		public IList<Pattern> pattern = new List<Pattern>();
+	}
+	// マップデータ
+	class MapData {
+		public string version = "map";
+		// マス
+		public IList<Position> position = new List<Position>();
+
+		public static MapData ReadFrom(string path) {
+			try {
+				return JsonConvert.DeserializeObject<MapData>(File.ReadAllText(path));
+			}
+			catch {
+				return null;
+			}
+		}
+		// JSON書き出し
+		public void WriteTo(string path) {
+			File.WriteAllText(path, JsonConvert.SerializeObject(this));
+		}
+	}
 	public class ListJsonConverter<T> : JsonConverter {
 		readonly string prefix;
 
@@ -247,6 +280,19 @@ namespace KCS_GUI {
 
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) {
 			serializer.Serialize(writer, ((IList<T>)value)?.Select((t, i) => new { k = $"{prefix}{i + 1}", t })?.ToDictionary(a => a.k, a => a.t));
+		}
+	}
+	public class KammusuIdJsonConverter : JsonConverter {
+		public override bool CanConvert(Type objectType) {
+			return objectType == typeof(Kammusu);
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) {
+			return new Kammusu(serializer.Deserialize<int>(reader));
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) {
+			serializer.Serialize(writer, ((Kammusu)value).id);
 		}
 	}
 }

--- a/KCS_GUI/JsonModels.cs
+++ b/KCS_GUI/JsonModels.cs
@@ -1,0 +1,2 @@
+﻿namespace KCS_GUI {
+}

--- a/KCS_GUI/JsonModels.cs
+++ b/KCS_GUI/JsonModels.cs
@@ -153,12 +153,14 @@ namespace KCS_GUI {
 		}
 
 		public Kammusu(int id) : this(id, 1, -1) {
-			items = row.初期装備
-				.Split('/')
-				.Select(Int32.Parse)
-				.Where(weaponID => 0 < weaponID)
-				.Select(weaponID => new Weapon(weaponID))
-				.ToList();
+			items = new BindingList<Weapon>(
+				row.初期装備
+					.Split('/')
+					.Select(Int32.Parse)
+					.Where(weaponID => 0 < weaponID)
+					.Select(weaponID => new Weapon(weaponID))
+					.ToList()
+			);
 		}
 	}
 	// 艦隊
@@ -184,7 +186,7 @@ namespace KCS_GUI {
 		}
 		// 艦娘
 		[JsonIgnore]
-		public IList<IList<Kammusu>> unit = Enumerable.Range(0, MaxFleetSize).Select(_ => (IList<Kammusu>)new List<Kammusu>()).ToList();
+		public IList<IList<Kammusu>> unit = new BindingList<IList<Kammusu>>(Enumerable.Range(0, MaxFleetSize).Select(_ => (IList<Kammusu>)new List<Kammusu>()).ToList());
 
 		[JsonExtensionData]
 		IDictionary<string, JToken> additionalData = new Dictionary<string, JToken>();
@@ -226,7 +228,7 @@ namespace KCS_GUI {
 	class Pattern {
 		public int form;
 		[JsonProperty(ItemConverterType = typeof(KammusuIdJsonConverter))]
-		public IList<Kammusu> fleets = new List<Kammusu>();
+		public IList<Kammusu> fleets = new BindingList<Kammusu>();
 	}
 	// マスデータ
 	class Position {
@@ -235,13 +237,13 @@ namespace KCS_GUI {
 		// マスの名称
 		public string name;
 		// 各パターン
-		public IList<Pattern> pattern = new List<Pattern>();
+		public IList<Pattern> pattern = new BindingList<Pattern>();
 	}
 	// マップデータ
 	class MapData {
 		public string version = "map";
 		// マス
-		public IList<Position> position = new List<Position>();
+		public IList<Position> position = new BindingList<Position>();
 
 		public static MapData ReadFrom(string path) {
 			try {
@@ -269,7 +271,7 @@ namespace KCS_GUI {
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) {
 			var dictionary = serializer.Deserialize<Dictionary<string, T>>(reader);
-			var list = (serializer.ObjectCreationHandling != ObjectCreationHandling.Replace ? existingValue as IList<T> : null) ?? new List<T>();
+			var list = (serializer.ObjectCreationHandling != ObjectCreationHandling.Replace ? existingValue as IList<T> : null) ?? new BindingList<T>();
 			for (var i = 1; ; i++) {
 				T t;
 				if (!dictionary.TryGetValue(prefix + i, out t))

--- a/KCS_GUI/JsonModels.cs
+++ b/KCS_GUI/JsonModels.cs
@@ -177,6 +177,7 @@ namespace KCS_GUI {
 			set { lv_ = value.limit(1, 120); }
 		}
 		// 艦隊形式
+		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 		public int type {
 			get { return type_; }
 			set { type_ = value.limit(0, 3); }

--- a/KCS_GUI/KCS_GUI.csproj
+++ b/KCS_GUI/KCS_GUI.csproj
@@ -47,6 +47,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CsvDataSet.cs">
+      <DependentUpon>CsvDataSet.xsd</DependentUpon>
+    </Compile>
     <Compile Include="CsvDataSet.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/KCS_GUI/KCS_GUI.csproj
+++ b/KCS_GUI/KCS_GUI.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Form1.Designer.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
+    <Compile Include="JsonModels.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Settings.Designer.cs">


### PR DESCRIPTION
#98 を前提にしています。

データバインド機構を使用することで、イベントハンドラの処理を簡素化しています。
順次変更中。

---

`ComboBox.Items`や`ListBox.Items`は実は`string`型でなく`object`型を受け付けています。これは任意のコレクションを保持できることを示唆しています。実際

```
this.WeaponSelectListBox.DisplayMember = "装備名";
```

とすることで当該オブジェクトの指定されたプロパティ値を画面表示します。更に

```
WeaponSelectListBox.DataSource = kammusu.items;
```

とリストを登録すると、リスト側の増減に自動的に追従します。
