### PR TITLE
method-chain-like function : support enum type

### DIFF
--- a/KCS_CUI/source/base.hpp
+++ b/KCS_CUI/source/base.hpp
@@ -89,7 +89,8 @@ namespace detail {
 		return (val < info.min) ? info.min : (info.max < val) ? info.max : val;
 	}
 }
-inline detail::to_i_helper<int> to_i() noexcept { return{}; }
+template<typename T = int, std::enable_if_t<std::is_arithmetic<T>::value, std::nullptr_t> = nullptr>
+inline detail::to_i_helper<T> to_i() noexcept { return{}; }
 inline detail::to_i_helper<size_t> to_sz() noexcept { return{}; }
 
 template<typename T>


### PR DESCRIPTION
``` cpp
FleetType(o | GetWithLimitOrDefault("type", int(FleetType::Normal), int(FleetType::CombinedDrum), int(FleetType::Normal)));
```

ってどう考えても汚いので

``` cpp
fleet_type_ = o | GetWithLimitOrDefault("type", FleetType::Normal, FleetType::CombinedDrum, FleetType::Normal);
```

とかけるように。利用時にキャストをせずに済むようになり、キャスト時に精度が落ちる可能性をなくした。
