### PR TITLE
update Clang with Microsoft CodeGen

### DIFF
--- a/KCS_CUI/KCS_CUI.vcxproj
+++ b/KCS_CUI/KCS_CUI.vcxproj
@@ -79,16 +79,16 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='clang_Debug|Win32'" Label="Configuration">
-    <PlatformToolset>v140_clang_3_7</PlatformToolset>
+    <PlatformToolset>v140_clang_c2</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='clang_Release|Win32'" Label="Configuration">
-    <PlatformToolset>v140_clang_3_7</PlatformToolset>
+    <PlatformToolset>v140_clang_c2</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='clang_Debug|x64'" Label="Configuration">
-    <PlatformToolset>v140_Clang_3_7</PlatformToolset>
+    <PlatformToolset>v140_clang_c2</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='clang_Release|x64'" Label="Configuration">
-    <PlatformToolset>v140_Clang_3_7</PlatformToolset>
+    <PlatformToolset>v140_clang_c2</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
@@ -211,6 +211,7 @@
       <AdditionalOptions>-Wextra %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -239,6 +240,7 @@
       <AdditionalOptions>-Wextra %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <DebugInformationFormat>FullDebug</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/KCS_CUI/source/char_convert.hpp
+++ b/KCS_CUI/source/char_convert.hpp
@@ -12,6 +12,10 @@ Distributed under the Boost Software License, Version 1.0.
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif //NOMINMAX
+//To avoid compile error
+//C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229,21): error : unknown type name 'IUnknown'
+//          static_cast<IUnknown*>(*pp);    // make sure everyone derives from IUnknown
+struct IUnknown;
 #include <windows.h>
 #include <cstring>
 namespace char_cvt {


### PR DESCRIPTION
プラットフォームツールセットの名前がClang 3.7 with Microsoft CodeGen (v140_clang_3_7)からVisual Studio 2015 - Clang with Microsoft CodeGen (v140_clang_c2)に変更になった。以前のバージョンのサポートを打ち切り移行する

ref: 
#137

Clang with Microsoft CodeGen(2016/07版)でWindows.hを使うときに注意すべきこと
http://qiita.com/yumetodo/items/a8c408078766a5c81e31
