### PR TITLE
fix compile error on Clang with Microsoft CodeGen

### DIFF
--- a/KCS_CUI/KCS_CUI.project
+++ b/KCS_CUI/KCS_CUI.project
@@ -70,7 +70,8 @@
       <PreBuild/>
       <PostBuild/>
       <CustomBuild Enabled="yes">
-        <Target Name="cmake">cmake . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
+        <Target Name="cmake gcc">cmake . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
+        <Target Name="cmake clang">cmake . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1  -DCMAKE_CXX_COMPILER=clang++</Target>
         <Target Name="Build_VERBOSE">make -j4  VERBOSE=1 2&gt;&amp;1</Target>
         <RebuildCommand>make clean &amp;&amp; make -j4</RebuildCommand>
         <CleanCommand>make clean</CleanCommand>
@@ -151,7 +152,8 @@
       <PreBuild/>
       <PostBuild/>
       <CustomBuild Enabled="yes">
-        <Target Name="cmake">cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
+        <Target Name="cmake gcc">cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
+        <Target Name="cmake clang">cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_COMPILER=clang++</Target>
         <RebuildCommand>make clean &amp;&amp; make -j4</RebuildCommand>
         <CleanCommand>make clean</CleanCommand>
         <BuildCommand>make -j4</BuildCommand>

--- a/KCS_CUI/KCS_CUI.project
+++ b/KCS_CUI/KCS_CUI.project
@@ -70,8 +70,8 @@
       <PreBuild/>
       <PostBuild/>
       <CustomBuild Enabled="yes">
-        <Target Name="cmake gcc">cmake . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
-        <Target Name="cmake clang">cmake . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1  -DCMAKE_CXX_COMPILER=clang++</Target>
+        <Target Name="cmake gcc">rm -rf CMakeFiles &amp;&amp; rm -f CMakeCache.txt &amp;&amp; cmake . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
+        <Target Name="cmake clang">rm -rf CMakeFiles &amp;&amp; rm -f CMakeCache.txt &amp;&amp; cmake . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1  -DCMAKE_CXX_COMPILER=clang++</Target>
         <Target Name="Build_VERBOSE">make -j4  VERBOSE=1 2&gt;&amp;1</Target>
         <RebuildCommand>make clean &amp;&amp; make -j4</RebuildCommand>
         <CleanCommand>make clean</CleanCommand>
@@ -152,8 +152,8 @@
       <PreBuild/>
       <PostBuild/>
       <CustomBuild Enabled="yes">
-        <Target Name="cmake gcc">cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
-        <Target Name="cmake clang">cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_COMPILER=clang++</Target>
+        <Target Name="cmake gcc">rm -rf CMakeFiles &amp;&amp; rm -f CMakeCache.txt &amp;&amp; cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=1</Target>
+        <Target Name="cmake clang">rm -rf CMakeFiles &amp;&amp; rm -f CMakeCache.txt &amp;&amp; cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_COMPILER=clang++</Target>
         <RebuildCommand>make clean &amp;&amp; make -j4</RebuildCommand>
         <CleanCommand>make clean</CleanCommand>
         <BuildCommand>make -j4</BuildCommand>

--- a/KCS_CUI/KCS_CUI.vcxproj
+++ b/KCS_CUI/KCS_CUI.vcxproj
@@ -56,7 +56,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>PGOptimize</WholeProgramOptimization>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
     <InterproceduralOptimization>true</InterproceduralOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release(AVX2)|Win32'" Label="Configuration">

--- a/KCS_CUI/source/CMakeLists.txt
+++ b/KCS_CUI/source/CMakeLists.txt
@@ -21,7 +21,17 @@ set(kcs_kai_src
 	simulator.cpp
 	weapon.cpp
 )
-
+if(MSVC)
+  # Force to always compile with W4
+  if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+    string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+  endif()
+elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+  # Update if necessary
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-long-long -pedantic")
+endif()
 ## Define the executable
 add_executable(KCS_CUI ${kcs_kai_src})
 target_link_libraries(KCS_CUI Threads::Threads)

--- a/KCS_CUI/source/base.hpp
+++ b/KCS_CUI/source/base.hpp
@@ -19,7 +19,10 @@
 #include <type_traits>
 #include "exception.hpp"
 #include "arithmetic_convert.hpp"
+
+#ifdef _MSC_VER
 #pragma warning( disable : 4592)
+#endif
 
 using std::cout;
 using std::bitset;

--- a/KCS_CUI/source/char_convert.hpp
+++ b/KCS_CUI/source/char_convert.hpp
@@ -71,7 +71,7 @@ namespace char_cvt {
 	}
 }
 #endif //_WIN32
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506 && !defined(__c2__)
 #include <algorithm>
 namespace char_cvt {
 	namespace detail {
@@ -105,7 +105,7 @@ namespace char_cvt {
 
 namespace char_cvt {
 	inline std::string u32tou8(const std::u32string& s) {
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506 && !defined(__c2__)
 		static std::wstring_convert<std::codecvt_utf8<__int32>, __int32> u8u32cvt;
 		return u8u32cvt.to_bytes(detail::u32_to_int32_string(s));
 #else
@@ -114,7 +114,7 @@ namespace char_cvt {
 #endif
 	}
 	inline std::u32string u8tou32(const std::string& s) {
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506 && !defined(__c2__)
 		static std::wstring_convert<std::codecvt_utf8<__int32>, __int32> u8u32cvt;
 		return detail::int32_to_u32_string(u8u32cvt.from_bytes(s));
 #else
@@ -123,7 +123,7 @@ namespace char_cvt {
 #endif
 	}
 	inline std::string u16tou8(const std::u16string& s) {
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506 && !defined(__c2__)
 		static td::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> u8u16cvt;
 		return u8u16cvt.to_bytes(detail::u16_to_int16_string(s));
 #else
@@ -132,7 +132,7 @@ namespace char_cvt {
 #endif
 	}
 	inline std::u16string u8tou16(const std::string& s) {
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER <= 190023506 && !defined(__c2__)
 		static std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> u8u16cvt;
 		return detail::int16_to_u16_string(u8u16cvt.from_bytes(s));
 #else

--- a/KCS_CUI/source/kammusu.hpp
+++ b/KCS_CUI/source/kammusu.hpp
@@ -93,6 +93,7 @@ inline std::wstring to_wstring(const ShipClass& sc) {
 }
 
 namespace detail {
+	using std::nullptr_t;
 	template<class F, class C, std::enable_if_t<!std::is_member_function_pointer<F>::value, nullptr_t> = nullptr>
 	auto invoke(F f, C c) { return f(c); }
 	template<class F, class C, std::enable_if_t<std::is_member_function_pointer<F>::value, nullptr_t> = nullptr>

--- a/KCS_CUI/source/std_future.hpp
+++ b/KCS_CUI/source/std_future.hpp
@@ -5,6 +5,6 @@ namespace std_future{
 	template <class C> 
 	constexpr auto size(const C& c) -> decltype(c.size()) { return c.size(); }
 	template <class T, std::size_t N>
-	constexpr std::size_t size(const T (&array)[N]) noexcept { return N; }
+	constexpr std::size_t size(const T (&)[N]) noexcept { return N; }
 }
 #endif //KCS_KAI_INC_KAMMUSU_STD_FUTURE_HPP_

--- a/KanColleSimulator_KAI.workspace
+++ b/KanColleSimulator_KAI.workspace
@@ -2,11 +2,11 @@
 <CodeLite_Workspace Name="KanColleSimulator_KAI" Database="KanColleSimulator_KAI.tags">
   <Project Name="KCS_CUI" Path="KCS_CUI/KCS_CUI.project" Active="Yes"/>
   <BuildMatrix>
-    <WorkspaceConfiguration Name="Debug" Selected="yes">
+    <WorkspaceConfiguration Name="Debug" Selected="no">
       <Environment/>
       <Project Name="KCS_CUI" ConfigName="Debug_Linux"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Release" Selected="no">
+    <WorkspaceConfiguration Name="Release" Selected="yes">
       <Environment/>
       <Project Name="KCS_CUI" ConfigName="Release_Linux"/>
     </WorkspaceConfiguration>


### PR DESCRIPTION
#149 でぽかしていた。
- Clang with Microsoft CodeGenでコンパイルが通らない。
- `-Wall -Wextra`のような警告オプションを`CMakeLists.txt`で指定していなかった。
- `#pragma warning`はVSの機能なので条件分岐するべきだった
# コンパイルチェック
- Visual Studio 2015 Update 3
  - [x] x64 Debug
  - [x] x64 Release
  - [x] Win32 Debug
  - [x] Win32 Release
- Visual Studio 2015 Clang with Microsoft CodeGen
  - [x] x64 clang_Debug
  - [x] x64 clang_Release
  - [x] Win32 clang_Debug
  - [x] Win32 clang_Release
- msys2 
  - mingw32  gcc 6.2.0
    - [x] Debug : `-G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Debug`
    - [x] Release : `-G "MSYS Makefiles"`
  - mingw64  gcc 6.2.0
    - [x] Debug : `-G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Debug`
    - [x] Release : `-G "MSYS Makefiles"`
  - mingw32  clang 3.8.0
    - [ ] Debug : `-G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++`
    - [ ] Release : `-G "MSYS Makefiles" -DCMAKE_CXX_COMPILER=clang++`
  - mingw64  clang 3.8.0
    - [ ] Debug : `-G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++`
    - [ ] Release : `-G "MSYS Makefiles" -DCMAKE_CXX_COMPILER=clang++`
- Ubuntu 16.04
  - gcc 5.4.0
    - [x] Debug
    - [x] Release
  - clang 3.8.0
    - [x] Debug
    - [x] Release
