### PR TITLE
Reduce alloc2

### DIFF
--- a/KCS_CUI/source/base.hpp
+++ b/KCS_CUI/source/base.hpp
@@ -41,11 +41,11 @@ using std::vector;
 using std::wcout;
 using std::size_t;
 
-constexpr int kBattleSize = 2;		//戦闘で戦うのは敵と味方の「2つ」
-constexpr int kMaxFleetSize = 2;	//
+constexpr size_t kMaxFleetSize = 2;	//
 constexpr size_t kMaxUnitSize = 6;		//艦隊に含まれる最大艦数
-constexpr int kFriendSide = 0;
+constexpr size_t kFriendSide = 0;
 constexpr size_t kEnemySide = 1;	//味方および敵陣営の番号付け
+constexpr size_t kBattleSize = 2;		//戦闘で戦うのは敵と味方の「2つ」
 
 enum class WeaponClass : std::uint64_t;
 

--- a/KCS_CUI/source/fleet.hpp
+++ b/KCS_CUI/source/fleet.hpp
@@ -29,6 +29,7 @@ public:
 	Fleet(std::istream &file, const Formation &formation, char_cvt::char_enc fileenc = char_cvt::char_enc::utf8);
 	// setter
 	void SetFormation(const Formation);
+	void ResizeUnit(size_t size);
 	// getter
 	Formation GetFormation() const noexcept;
 	vector<vector<Kammusu>>& GetUnit() noexcept;

--- a/KCS_CUI/source/main.cpp
+++ b/KCS_CUI/source/main.cpp
@@ -122,10 +122,10 @@ public:
 		for (size_t p = 0; p < map_Data.GetSize(); ++p) {
 			wcout << map_Data.GetPointName(p) << L"マス到達率：" << (100.0 * point_count[p] / config.GetTimes()) << L"％" << endl;
 			if (p != map_Data.GetSize() - 1) {
-				cout << "道中撤退率：" << (100.0 * (point_count[p] - point_count[p + 1]) / point_count[p]) << "％\n" << endl;
+				wcout << L"道中撤退率：" << (100.0 * (point_count[p] - point_count[p + 1]) / point_count[p]) << L"％\n" << endl;
 			}
 			else {
-				cout << "\nボスマスにおける統計：" << endl;
+				wcout << L"\nボスマスにおける統計：" << endl;
 			}
 		}
 		vector<Fleet> fleet(kBattleSize);
@@ -148,7 +148,7 @@ template<class Mode>
 void run(const time_point<high_resolution_clock>& preprocess_begin_time, Config& config) {
 	Mode mode{ config };
 	const auto preprocess_end_time = high_resolution_clock::now();
-	cout << "preprocess:" << duration_cast<nanoseconds>(preprocess_end_time - preprocess_begin_time).count() << "[ns]\n" << endl;
+	wcout << L"preprocess:" << duration_cast<nanoseconds>(preprocess_end_time - preprocess_begin_time).count() << L"[ns]\n" << endl;
 	const auto process_begin_time = high_resolution_clock::now();
 	if (1 < config.GetThreads()) {
 		std::vector<std::thread> threads;
@@ -160,7 +160,7 @@ void run(const time_point<high_resolution_clock>& preprocess_begin_time, Config&
 	} else
 		mode.work();
 	const auto process_end_time = high_resolution_clock::now();
-	cout << "処理時間：" << duration_cast<milliseconds>(process_end_time - process_begin_time).count() << "[ms]\n" << endl;
+	wcout << L"処理時間：" << duration_cast<milliseconds>(process_end_time - process_begin_time).count() << L"[ms]\n" << endl;
 	mode.show_result();
 }
 

--- a/KCS_CUI/source/main.cpp
+++ b/KCS_CUI/source/main.cpp
@@ -98,7 +98,7 @@ public:
 				}
 				// シミュレートを行う
 				Simulator simulator(fleet, map_data_this_thread.GetSimulateMode(p));
-				vector<Fleet> fleet_;
+				std::array<Fleet, kBattleSize> fleet_;
 				Result result_;
 				std::tie(result_, fleet_) = simulator.Calc();
 				// 結果を元の配列に書き戻す

--- a/KCS_CUI/source/main.cpp
+++ b/KCS_CUI/source/main.cpp
@@ -98,7 +98,7 @@ public:
 				}
 				// シミュレートを行う
 				Simulator simulator(fleet, map_data_this_thread.GetSimulateMode(p));
-				std::array<Fleet, kBattleSize> fleet_;
+				vector<Fleet> fleet_(kBattleSize);
 				Result result_;
 				std::tie(result_, fleet_) = simulator.Calc();
 				// 結果を元の配列に書き戻す

--- a/KCS_CUI/source/mapdata.cpp
+++ b/KCS_CUI/source/mapdata.cpp
@@ -32,7 +32,7 @@ MapData::MapData(const string &file_name, char_cvt::char_enc fileenc) {
 			auto formation_ = Formation(stoi(o5.at("form").to_str())) | limit(kFormationTrail, kFormationAbreast);
 			temp.SetFormation(formation_);
 			auto &o6 = o5.at("fleets").get<picojson::array>();
-			temp.GetUnit().resize(1);
+			temp.ResizeUnit(1);
 			for (auto &it3 : o6) {
 				auto id = stoi(it3.to_str());
 				auto kammusu = Kammusu::Get(id, 1).Reset(true);

--- a/KCS_CUI/source/random.hpp
+++ b/KCS_CUI/source/random.hpp
@@ -33,6 +33,7 @@ public:
 	}
 	template<typename T>
 	static const auto& select_random_in_range(const T& v) {
+		INVAID_ARGUMENT_THROW_WITH_MESSAGE_IF(std_future::size(v) < 1, "range is empty.");
 		return select_random_in_range(v, std_future::size(v));
 	}
 };

--- a/KCS_CUI/source/result.cpp
+++ b/KCS_CUI/source/result.cpp
@@ -61,7 +61,7 @@ WinReason Result::JudgeWinReason() const noexcept {
 		dead_count[bi] = alived_count_before[bi] - alived_count[bi];
 	}
 	// 戦果ゲージを算出する
-	vector<double> result_per(kBattleSize);				//戦果ゲージ(敵艦隊の撃沈割合であることに注意)
+	std::array<double, kBattleSize> result_per = { {} };				//戦果ゲージ(敵艦隊の撃沈割合であることに注意)
 	for (size_t bi = 0; bi < kBattleSize; ++bi) {
 		auto other_side = kBattleSize - bi - 1;
 		result_per[bi] = 1.0 * (hp_before_sum[other_side] - hp_sum[other_side]) / hp_before_sum[other_side];

--- a/KCS_CUI/source/simulator.cpp
+++ b/KCS_CUI/source/simulator.cpp
@@ -216,7 +216,8 @@ void Simulator::FitstAntiSubPhase() {
 void Simulator::AirWarPhase() {
 	// 制空状態の決定
 	//制空値を計算する
-	vector<int> anti_air_score(2);
+	std::array<int, kBattleSize> anti_air_score = { {} };
+	static_assert(2 == kBattleSize, "kBattleSize should be 2.");
 	for (size_t i = 0; i < kBattleSize; ++i) {
 		anti_air_score[i] = fleet_[i].AntiAirScore();
 	}
@@ -336,7 +337,7 @@ void Simulator::AirWarPhase() {
 
 	// 開幕爆撃
 	//ダメージ計算
-	vector<vector<vector<int>>> all_damage(kBattleSize, vector<vector<int>>(kMaxFleetSize, vector<int>(kMaxUnitSize, 0)));
+	std::array<std::array<std::array<int, kMaxUnitSize>, kMaxFleetSize>, kBattleSize> all_damage = { {} };
 	for (size_t bi = 0; bi < kBattleSize; ++bi) {
 		auto other_side = kBattleSize - bi - 1;
 		auto &friend_unit = fleet_[bi].GetUnit().front();
@@ -438,9 +439,9 @@ void Simulator::BattlePositionOracle() noexcept {
 // (開幕)雷撃フェイズ
 void Simulator::TorpedoPhase(const TorpedoTurn &torpedo_turn) {
 	// ダメージ計算
-	vector<vector<int>> all_damage(kBattleSize, vector<int>(kMaxUnitSize, 0));
+	std::array<std::array<int, kMaxUnitSize>, kBattleSize> all_damage = { {} };
 	for (size_t bi = 0; bi < kBattleSize; ++bi) {
-		auto other_side = kBattleSize - bi - 1;
+		const auto other_side = kBattleSize - 1 - bi;
 		auto &friend_unit = fleet_[bi].GetUnit().back();
 		for (size_t ui = 0; ui < friend_unit.size(); ++ui) {
 			auto &hunter_kammusu = friend_unit[ui];
@@ -482,9 +483,9 @@ void Simulator::TorpedoPhase(const TorpedoTurn &torpedo_turn) {
 #endif
 }
 
-vector<vector<std::pair<KammusuIndex, Range>>> Simulator::DetermineAttackOrder(FireTurn fire_turn, size_t /*fleet_index*/) const
+std::array<vector<std::pair<KammusuIndex, Range>>, kBattleSize> Simulator::DetermineAttackOrder(FireTurn fire_turn, size_t /*fleet_index*/) const
 {
-	vector<vector<std::pair<KammusuIndex, Range>>> attack_list(kBattleSize);
+	std::array<vector<std::pair<KammusuIndex, Range>>, kBattleSize> attack_list = { {} };
 	for (size_t bi = 0; bi < kBattleSize; ++bi) {
 		auto &unit = this->fleet_[bi].GetUnit();
 		// 行動可能な艦娘一覧を作成する
@@ -696,7 +697,7 @@ void Simulator::NightPhase() {
 }
 
 // 制空状態を判断する
-AirWarStatus Simulator::JudgeAirWarStatus(const vector<int> &anti_air_score) {
+AirWarStatus Simulator::JudgeAirWarStatus(const std::array<int, kBattleSize> &anti_air_score) {
 	// どちらも航空戦に参加する艦載機を持っていなかった場合は航空均衡
 	if (!fleet_[kFriendSide].HasAirFight() && !fleet_[kEnemySide].HasAirFight()) {
 		return kAirWarStatusNormal;

--- a/KCS_CUI/source/simulator.hpp
+++ b/KCS_CUI/source/simulator.hpp
@@ -50,13 +50,13 @@ class Simulator {
 	void AirWarPhase();
 	void BattlePositionOracle() noexcept;
 	void TorpedoPhase(const TorpedoTurn&);
-	vector<vector<std::pair<KammusuIndex, Range>>> DetermineAttackOrder(FireTurn fire_turn, size_t fleet_index = 0) const;
+	std::array<vector<std::pair<KammusuIndex, Range>>, kBattleSize> DetermineAttackOrder(FireTurn fire_turn, size_t fleet_index = 0) const;
 	std::tuple<bool, bool, double> CalcLandingObservationShootingCorrection(DayFireType fire_type, size_t bi, const Kammusu & hunter_kammusu, size_t other_side, KammusuIndex friend_index) const;
 	void FirePhase(const FireTurn&, const size_t &fleet_index = 0);
 	void NightPhase();
 	// 計算用メソッド(内部)
 	//制空状態を判断する
-	AirWarStatus JudgeAirWarStatus(const vector<int>&);
+	AirWarStatus JudgeAirWarStatus(const std::array<int, kBattleSize>&);
 	//与えるダメージ量を計算する
 	int CalcDamage(
 		const BattlePhase&, const size_t, const KammusuIndex&, KammusuIndex&, const int&,


### PR DESCRIPTION
ref : #64 
- `Simulator::AirWarPhase`の`vector<int> anti_air_score`をarrayに
- `Fleet::RandomKammusuSS`の`vector<size_t> list`の除去
- `Simulator::TorpedoPhase`の`vector<vector<int>> all_damage`のarray化
- `Result::JudgeWinReason`からvectorを排除
